### PR TITLE
✨ 직접 텍스트 입력 기능 추가

### DIFF
--- a/api/generate-post.ts
+++ b/api/generate-post.ts
@@ -6,14 +6,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(405).json({ error: "Method Not Allowed" });
   }
 
-  const { newsContents } = req.body;
+  const { references } = req.body;
 
-  if (!newsContents) {
+  if (!references) {
     return res.status(400).json({ error: "News contents are required" });
   }
 
   try {
-    const generatedPost = await generatePost(newsContents);
+    const generatedPost = await generatePost(references);
     return res.status(200).json({ result: generatedPost });
   } catch (error) {
     console.error("Error generating post:", error);

--- a/backend/services/PostService.ts
+++ b/backend/services/PostService.ts
@@ -4,9 +4,9 @@ import { StringOutputParser } from "@langchain/core/output_parsers";
 import { generatePostPrompt } from "../prompts/generatePostPrompt.js";
 
 export async function generatePost(
-  newsContents: { text: string }[]
+  references: { text: string }[]
 ): Promise<string> {
-  const formattedReferences = newsContents
+  const formattedReferences = references
     .map((ref) => formatReference(ref))
     .join("\n\n");
 

--- a/src/components/DirectTextInput.vue
+++ b/src/components/DirectTextInput.vue
@@ -1,0 +1,130 @@
+<template>
+  <div class="w-full max-w-xl">
+    <div v-for="(text, index) in texts" :key="index" class="mb-6">
+      <Panel :toggleable="true" :pt="panelPt">
+        <template #header>
+          <div class="flex justify-between items-center w-full">
+            <span class="text-lg font-semibold"
+              >텍스트 소스 {{ index + 1 }}</span
+            >
+            <Button
+              icon="pi pi-trash"
+              @click="removeText(index)"
+              severity="danger"
+              text
+              aria-label="삭제"
+              :pt="{
+                root: {
+                  class:
+                    'p-2 hover:bg-red-100 rounded-full transition-colors duration-200',
+                },
+              }"
+            />
+          </div>
+        </template>
+        <div class="p-4">
+          <Textarea
+            v-model="texts[index]"
+            :autoResize="true"
+            rows="5"
+            placeholder="텍스트를 입력하거나 붙여넣기 하세요..."
+            class="w-full mb-2"
+            :pt="textareaPt"
+          />
+          <small class="text-gray-500 block text-right">
+            {{ texts[index].length }} / 3000 글자
+          </small>
+        </div>
+      </Panel>
+    </div>
+    <div class="flex justify-between items-center mt-6">
+      <Button
+        @click="addText"
+        label="다른 텍스트 추가"
+        icon="pi pi-plus"
+        outlined
+        :disabled="texts.length >= 5"
+        :pt="primaryButtonPt"
+      />
+      <Button
+        @click="generatePost"
+        label="포스트 생성"
+        icon="pi pi-file-edit"
+        :disabled="!isValid"
+        :pt="primaryButtonPt"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed } from "vue";
+import Panel from "primevue/panel";
+import Textarea from "primevue/textarea";
+import Button from "primevue/button";
+
+export default defineComponent({
+  components: { Panel, Textarea, Button },
+  emits: ["generate"],
+  setup(props, { emit }) {
+    const texts = ref([""]);
+
+    const panelPt = {
+      root: {
+        class: "shadow-md rounded-lg overflow-hidden border border-gray-200",
+      },
+      header: { class: "bg-gray-50 p-4 border-b border-gray-200" },
+      content: { class: "bg-white" },
+      toggleableContent: { class: "transition-all duration-300 ease-in-out" },
+    };
+
+    const textareaPt = {
+      root: {
+        class:
+          "w-full p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all duration-200",
+      },
+    };
+
+    const buttonPt = {
+      root: {
+        class:
+          "bg-primary-600 hover:bg-primary-700 text-primary-50 font-bold px-6 py-3 rounded-md transition-colors duration-200 shadow-md hover:shadow-lg",
+      },
+    };
+
+    const addText = () => {
+      if (texts.value.length < 5) {
+        texts.value.push("");
+      }
+    };
+
+    const removeText = (index: number) => {
+      texts.value.splice(index, 1);
+    };
+
+    const isValid = computed(() =>
+      texts.value.some((text) => text.trim() !== "")
+    );
+
+    const generatePost = () => {
+      if (isValid.value) {
+        emit(
+          "generate",
+          texts.value.filter((text) => text.trim() !== "")
+        );
+      }
+    };
+
+    return {
+      texts,
+      panelPt,
+      textareaPt,
+      primaryButtonPt: buttonPt,
+      addText,
+      removeText,
+      isValid,
+      generatePost,
+    };
+  },
+});
+</script>

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -3,7 +3,15 @@
     class="flex flex-col justify-center items-center min-h-screen px-4 bg-gray-50"
   >
     <h1 class="text-5xl font-bold mb-12 text-primary-800">Post.ly</h1>
-    <div class="w-full max-w-xl mb-6">
+
+    <SelectButton
+      v-model="inputMode"
+      :options="inputModes"
+      optionLabel="name"
+      class="mb-4"
+    />
+
+    <div v-if="inputMode.value === 'keyword'" class="w-full max-w-xl mb-6">
       <IconField class="w-full" :pt="{ root: 'relative w-full' }">
         <InputText
           v-model="topic"
@@ -22,8 +30,15 @@
         </InputIcon>
       </IconField>
     </div>
+
+    <DirectTextInput v-else @generate="generatePostFromText" />
+
     <p class="text-gray-600 text-lg max-w-md text-center mt-4">
-      관련 뉴스를 찾아 포스트를 생성해드려요 ☺️
+      {{
+        inputMode.value === "keyword"
+          ? "관련 뉴스를 찾아 포스트를 생성해드려요 ☺️"
+          : "입력한 텍스트를 기반으로 포스트를 생성해드려요 ☺️"
+      }}
     </p>
   </div>
 </template>
@@ -35,17 +50,27 @@ import { useArticleStore } from "../stores/articleStore";
 import InputText from "primevue/inputtext";
 import IconField from "primevue/iconfield";
 import InputIcon from "primevue/inputicon";
+import SelectButton from "primevue/selectbutton";
+import DirectTextInput from "../components/DirectTextInput.vue";
 
 export default defineComponent({
   components: {
     InputText,
     IconField,
     InputIcon,
+    SelectButton,
+    DirectTextInput,
   },
   setup() {
     const topic = ref("");
     const router = useRouter();
     const articleStore = useArticleStore();
+
+    const inputModes = ref([
+      { name: "키워드로 생성하기", value: "keyword" },
+      { name: "직접 텍스트 입력하기", value: "text" },
+    ]);
+    const inputMode = ref(inputModes.value[0]);
 
     const generatePost = async () => {
       if (topic.value.trim()) {
@@ -54,7 +79,12 @@ export default defineComponent({
       }
     };
 
-    return { topic, generatePost };
+    const generatePostFromText = async (texts: string[]) => {
+      await articleStore.setDirectTexts(texts);
+      router.push("/result");
+    };
+
+    return { topic, generatePost, inputModes, inputMode, generatePostFromText };
   },
 });
 </script>

--- a/src/pages/ResultPage.vue
+++ b/src/pages/ResultPage.vue
@@ -59,6 +59,7 @@ export default defineComponent({
 
     const reset = () => {
       articleStore.setTopic("");
+      articleStore.setDirectTexts([]);
       router.push("/");
     };
 


### PR DESCRIPTION
### TL;DR

Added a new feature to allow users to input text directly for post generation, alongside the existing keyword-based generation.

### What changed?

- Introduced a new `DirectTextInput` component for direct text input
- Updated `HomePage` to include a toggle between keyword and direct text input modes
- Modified the `articleStore` to handle both keyword-based and direct text input for post generation
- Adjusted the API endpoint to accept `references` instead of `newsContents`
- Updated the `ResultPage` to reset both topic and direct texts when navigating back to the home page

### How to test?

1. Navigate to the home page
2. Toggle between "키워드로 생성하기" and "직접 텍스트 입력하기" modes
3. For keyword mode:
   - Enter a topic and generate a post
4. For direct text input mode:
   - Add one or more text inputs (up to 5)
   - Enter or paste text into each input
   - Generate a post using the entered texts
5. Verify that the generated post appears on the result page
6. Test the reset functionality by returning to the home page

### Why make this change?

This change provides users with more flexibility in generating posts. While the keyword-based approach is useful for creating content from news articles, the direct text input allows users to leverage their own sources or ideas. This enhancement broadens the application's utility and caters to a wider range of use cases and user preferences.