### PR TITLE
🐛 api parameter 수정

### DIFF
--- a/src/stores/articleStore.ts
+++ b/src/stores/articleStore.ts
@@ -31,7 +31,7 @@ export const useArticleStore = defineStore("article", {
 
           // 2. Generate post
           response = await axios.post(`${API_URL}/generate-post`, {
-            newsContents: newsContents,
+            references: newsContents,
           });
         } else {
           // Generate post from direct texts


### PR DESCRIPTION
### TL;DR

Updated the payload key in the API request for generating posts.

### What changed?

The key `newsContents` in the axios POST request to `/generate-post` has been renamed to `references`.

### How to test?

1. Navigate to the article generation feature.
2. Attempt to generate a post using news contents.
3. Monitor the network requests and verify that the payload uses the key `references` instead of `newsContents`.
4. Ensure the post generation still works as expected with this change.

### Why make this change?

This change likely aligns the frontend payload with updated backend expectations, improving consistency in terminology between the client and server. The term "references" may more accurately describe the nature of the data being sent, potentially encompassing a broader range of source materials beyond just news contents.