### PR TITLE
💄 Toast 적용

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from "vue";
 import PrimeVue from "primevue/config";
+import ToastService from "primevue/toastservice";
 import App from "./App.vue";
 import router from "./router";
 import { createPinia } from "pinia";
@@ -14,4 +15,5 @@ app.use(PrimeVue, {
   unstyled: true,
   pt: Lara,
 });
+app.use(ToastService);
 app.mount("#app");

--- a/src/pages/ResultPage.vue
+++ b/src/pages/ResultPage.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="result-page">
+    <Toast />
     <template v-if="isLoading">
       <LoadingComponent />
     </template>
@@ -16,6 +17,7 @@
       <GeneratedPost :content="generatedPost" />
       <div class="flex justify-center gap-4 mt-4">
         <Button label="처음으로" @click="reset" class="p-button-secondary" />
+        <Toast position="bottom-center" group="bc" />
         <Button
           label="포스트 복사하기"
           @click="copyPost"
@@ -34,14 +36,17 @@ import LoadingComponent from "../components/LoadingComponent.vue";
 import { useArticleStore } from "../stores/articleStore";
 import Button from "primevue/button";
 import Message from "primevue/message";
+import Toast from "primevue/toast";
+import { useToast } from "primevue/usetoast";
 
 export default defineComponent({
-  components: { GeneratedPost, LoadingComponent, Button, Message },
+  components: { GeneratedPost, LoadingComponent, Button, Message, Toast },
   setup() {
     const router = useRouter();
     const articleStore = useArticleStore();
     const isLoading = ref(true);
     const error = ref("");
+    const toast = useToast();
 
     onMounted(async () => {
       try {
@@ -67,7 +72,13 @@ export default defineComponent({
 
     const copyPost = () => {
       navigator.clipboard.writeText(generatedPost.value);
-      alert("포스트가 복사되었습니다.");
+      toast.add({
+        severity: "success",
+        summary: "성공",
+        detail: "포스트가 복사되었습니다.",
+        life: 3000,
+        group: "bc",
+      });
     };
 
     return {


### PR DESCRIPTION
### TL;DR

Added Toast notifications and improved user feedback for post copying.

### What changed?

- Integrated PrimeVue's ToastService in the main application setup.
- Added Toast components to the ResultPage for displaying notifications.
- Replaced the alert for successful post copying with a more user-friendly Toast notification.

### How to test?

1. Navigate to the ResultPage.
2. Generate a post or ensure there's content to copy.
3. Click the "포스트 복사하기" (Copy Post) button.
4. Verify that a Toast notification appears at the bottom-center of the screen with the message "포스트가 복사되었습니다." (Post has been copied).
5. Confirm that the post content is actually copied to the clipboard.

### Why make this change?

This change enhances the user experience by providing more elegant and non-intrusive feedback when actions are performed. Toast notifications are less disruptive than traditional alerts and offer a more modern look and feel. Additionally, this implementation allows for consistent styling and positioning of notifications across the application.