### PR TITLE
⚰️ 불필요한 코드 제거

### DIFF
--- a/src/components/GeneratedPost.vue
+++ b/src/components/GeneratedPost.vue
@@ -70,22 +70,3 @@ export default defineComponent({
   },
 });
 </script>
-
-<style scoped>
-:deep(.p-card) {
-  box-shadow: none;
-}
-
-:deep(.p-card-body) {
-  padding: 0;
-}
-
-:deep(.p-card-content) {
-  padding: 0;
-}
-
-:deep(.p-card-header) {
-  padding: 0;
-  background-color: transparent;
-}
-</style>


### PR DESCRIPTION
### TL;DR

Removed scoped styles from GeneratedPost component.

### What changed?

Removed the entire `<style scoped>` section from the GeneratedPost.vue file. This section contained CSS rules for deep selectors targeting various PrimeVue card elements.

### How to test?

1. Open the GeneratedPost component in the browser.
2. Verify that the card appearance has not been significantly affected.
3. Check if any global styles or parent component styles are now applied to the card elements.
4. Ensure that the removal of these styles hasn't caused any unintended visual regressions.

### Why make this change?

The removal of these scoped styles suggests that:

1. The styling for the card elements is now being handled elsewhere, possibly in a global stylesheet or a parent component.
2. The custom styling for these elements was no longer necessary or was conflicting with other styles.
3. This change may be part of a larger effort to standardize component styling or to reduce component-specific CSS overrides.