### PR TITLE
♻️ seperate concerns

### DIFF
--- a/src/pages/ResultPage.vue
+++ b/src/pages/ResultPage.vue
@@ -69,7 +69,8 @@ export default defineComponent({
 
     onMounted(async () => {
       try {
-        await articleStore.generatePost();
+        const references = await articleStore.getReferences();
+        await articleStore.createPost(references);
       } catch (e: unknown) {
         error.value =
           e instanceof Error

--- a/src/stores/articleStore.ts
+++ b/src/stores/articleStore.ts
@@ -16,40 +16,24 @@ export const useArticleStore = defineStore("article", {
     setDirectTexts(texts: string[]) {
       this.directTexts = texts;
     },
-    async generatePost() {
+    async getReferences() {
       if (!this.topic && this.directTexts.length === 0) {
         throw new Error("주제 또는 텍스트가 설정되지 않았습니다.");
       }
-      try {
-        let response;
-        if (this.topic) {
-          // 1. Fetch news content
-          const newsContentResponse = await axios.get(
-            `${API_URL}/news-contents?query=${this.topic}`
-          );
-          const newsContents = newsContentResponse.data.newsContents;
-
-          // 2. Generate post
-          response = await axios.post(`${API_URL}/generate-post`, {
-            references: newsContents,
-          });
-        } else {
-          // Generate post from direct texts
-          response = await axios.post(`${API_URL}/generate-post`, {
-            references: this.directTexts.map((text) => ({ text })),
-          });
-        }
-        this.generatedPost = response.data.result;
-      } catch (error) {
-        console.error("Error generating post:", error);
-        if (axios.isAxiosError(error) && error.response) {
-          throw new Error(
-            error.response.data.error || "포스트 생성 중 오류가 발생했습니다."
-          );
-        } else {
-          throw error;
-        }
+      if (this.topic) {
+        const response = await axios.get(
+          `${API_URL}/news-contents?query=${this.topic}`
+        );
+        return response.data.newsContents;
+      } else {
+        return this.directTexts.map((text) => ({ text }));
       }
+    },
+    async createPost(references: { text: string }[]) {
+      const response = await axios.post(`${API_URL}/generate-post`, {
+        references,
+      });
+      this.generatedPost = response.data.result;
     },
   },
 });


### PR DESCRIPTION
### TL;DR

Refactored post generation process in the article store and updated the ResultPage component accordingly.

### What changed?

- Split the `generatePost` method in `articleStore` into two separate methods: `getReferences` and `createPost`.
- `getReferences` now handles fetching news contents or preparing direct texts.
- `createPost` takes references as a parameter and generates the post.
- Updated the `ResultPage` component to use the new methods sequentially.

### How to test?

1. Navigate to the ResultPage.
2. Enter a topic or provide direct texts.
3. Verify that the post generation process completes successfully.
4. Check if the generated post is displayed correctly.
5. Test both scenarios: using a topic and using direct texts.

### Why make this change?

This refactoring improves the separation of concerns in the article generation process. By splitting the functionality into distinct methods, it enhances code readability and maintainability. It also allows for more flexibility in handling different scenarios (topic-based or direct text-based generation) and potential future extensions to the post generation workflow.