### PR TITLE
♻️ seperate concerns in NewsService

### DIFF
--- a/backend/services/NewsService.ts
+++ b/backend/services/NewsService.ts
@@ -14,16 +14,18 @@ export async function fetchNewsContent(
   topic: string
 ): Promise<{ text: string }[]> {
   const newsItems = await searchNews(topic);
+  const filteredNewsItems = filterNewsItems(newsItems);
 
-  if (newsItems.length === 0) {
+  if (filteredNewsItems.length === 0) {
     throw new Error(
       "해당 주제에 대한 네이버 뉴스를 찾을 수 없습니다. 다른 주제로 시도해주세요."
     );
   }
 
   const contents = await Promise.all(
-    newsItems.map((item) => fetchContent(item.link))
+    filteredNewsItems.map((item) => fetchAndParseNewsContent(item.link))
   );
+
   const validContents = contents
     .filter((content) => content.length > 0)
     .map((content) => ({ text: content }));
@@ -41,6 +43,7 @@ async function searchNews(query: string): Promise<NewsItem[]> {
       params: {
         query: query,
         display: 30,
+        sort: "sim",
       },
       headers: {
         "X-Naver-Client-Id": NAVER_CLIENT_ID,
@@ -48,38 +51,53 @@ async function searchNews(query: string): Promise<NewsItem[]> {
       },
     });
 
-    return response.data.items
-      .filter(
-        (item: NewsItem) =>
-          item.link.startsWith("https://n.news.naver.com/") ||
-          item.link.startsWith("https://m.entertain.naver.com/") ||
-          item.link.startsWith("https://m.sports.naver.com/")
-      )
-      .slice(0, 3);
+    return response.data.items;
   } catch (error) {
     console.error("Failed to fetch news:", error);
     throw new Error("Failed to fetch news");
   }
 }
 
-async function fetchContent(url: string): Promise<string> {
+function filterNewsItems(newsItems: NewsItem[]): NewsItem[] {
+  return newsItems
+    .filter(
+      (item: NewsItem) =>
+        item.link.startsWith(NAVER_NEWS_URL) ||
+        item.link.startsWith(NAVER_ENTERTAIN_URL) ||
+        item.link.startsWith(NAVER_SPORTS_URL)
+    )
+    .slice(0, 3);
+}
+
+async function fetchAndParseNewsContent(url: string): Promise<string> {
   try {
-    const response = await axios.get(url);
-    const $ = cheerio.load(response.data);
-    let content = "";
-
-    if (url.startsWith(NAVER_NEWS_URL)) {
-      content = $("#dic_area").text();
-    } else if (
-      url.startsWith(NAVER_ENTERTAIN_URL) ||
-      url.startsWith(NAVER_SPORTS_URL)
-    ) {
-      content = $("#_article_content").text();
-    }
-
-    return content.trim();
+    const htmlContent = await fetchHtmlContent(url);
+    return parseNewsContent(url, htmlContent);
   } catch (error) {
-    console.error(`Failed to fetch news content from ${url}:`, error);
+    console.error(`Failed to fetch or parse news content from ${url}:`, error);
     return "";
   }
+}
+
+async function fetchHtmlContent(url: string): Promise<string> {
+  const response = await axios.get(url);
+  return response.data;
+}
+
+function parseNewsContent(url: string, htmlContent: string): string {
+  const $ = cheerio.load(htmlContent);
+  let content = "a";
+
+  if (url.startsWith(NAVER_NEWS_URL)) {
+    content = $("#dic_area").text();
+  } else if (
+    url.startsWith(NAVER_ENTERTAIN_URL) ||
+    url.startsWith(NAVER_SPORTS_URL)
+  ) {
+    content = $("div._article_content").text();
+  }
+
+  console.log(`content: ${content} for url: ${url}`);
+
+  return content.trim();
 }


### PR DESCRIPTION
### TL;DR

Improved news fetching and content parsing for Naver news articles.

### What changed?

- Added a `filterNewsItems` function to separate the filtering logic from the `searchNews` function.
- Introduced `fetchAndParseNewsContent` function to handle both fetching and parsing of news content.
- Separated HTML content fetching and parsing into distinct functions: `fetchHtmlContent` and `parseNewsContent`.
- Updated the news search query to sort results by similarity.
- Modified the content extraction selector for entertainment and sports articles.
- Added logging for parsed content and corresponding URLs.

### How to test?

1. Run the news fetching service with various topics.
2. Verify that news articles are correctly filtered and limited to 3 items.
3. Check if content is properly extracted for different types of Naver news URLs (regular news, entertainment, and sports).
4. Monitor the console logs to ensure content is being parsed correctly for each URL.

### Why make this change?

This refactoring improves code organization, maintainability, and error handling. By separating concerns and introducing more specific functions, it becomes easier to debug and extend the news fetching functionality. The added logging will help in identifying any issues with content parsing for different news sources.