### PR TITLE
♻️  refactor articlestore

### DIFF
--- a/src/composables/usePostGeneration.ts
+++ b/src/composables/usePostGeneration.ts
@@ -1,4 +1,4 @@
-import { ref, computed } from "vue";
+import { ref } from "vue";
 import { useRouter } from "vue-router";
 import { useArticleStore } from "../stores/articleStore";
 import { useToast } from "primevue/usetoast";
@@ -11,12 +11,12 @@ export function usePostGeneration() {
   const isLoading = ref(true);
   const loadingStage = ref("references");
   const error = ref("");
-
-  const generatedPost = computed(() => articleStore.generatedPost || "");
+  const generatedPost = ref("");
 
   const reset = () => {
     articleStore.setTopic("");
     articleStore.setDirectTexts([]);
+    generatedPost.value = "";
     router.push("/");
   };
 
@@ -37,7 +37,7 @@ export function usePostGeneration() {
       const references = await articleStore.getReferences();
 
       loadingStage.value = "generating";
-      await articleStore.createPost(references);
+      generatedPost.value = await articleStore.createPost(references);
 
       loadingStage.value = "finalizing";
       await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/src/stores/articleStore.ts
+++ b/src/stores/articleStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import axios from "axios";
+import type { Reference } from "../types";
 
 const API_URL = process.env.VUE_APP_API_URL;
 
@@ -7,7 +8,6 @@ export const useArticleStore = defineStore("article", {
   state: () => ({
     topic: "",
     directTexts: [] as string[],
-    generatedPost: "",
   }),
   actions: {
     setTopic(newTopic: string) {
@@ -16,7 +16,7 @@ export const useArticleStore = defineStore("article", {
     setDirectTexts(texts: string[]) {
       this.directTexts = texts;
     },
-    async getReferences() {
+    async getReferences(): Promise<Reference[]> {
       if (!this.topic && this.directTexts.length === 0) {
         throw new Error("주제 또는 텍스트가 설정되지 않았습니다.");
       }
@@ -29,11 +29,11 @@ export const useArticleStore = defineStore("article", {
         return this.directTexts.map((text) => ({ text }));
       }
     },
-    async createPost(references: { text: string }[]) {
+    async createPost(references: Reference[]): Promise<string> {
       const response = await axios.post(`${API_URL}/generate-post`, {
         references,
       });
-      this.generatedPost = response.data.result;
+      return response.data.result;
     },
   },
 });


### PR DESCRIPTION
### TL;DR

Refactored post generation logic and improved state management in the article store.

### What changed?

- Removed `computed` import from Vue and replaced `generatedPost` computed property with a ref in `usePostGeneration.ts`.
- Updated `reset` function to clear `generatedPost` ref.
- Modified `createPost` function to set `generatedPost` value directly instead of using the store.
- Removed `generatedPost` from the article store state.
- Updated `createPost` action in the article store to return the generated post instead of setting it in the store.
- Added type annotation for `getReferences` return value in the article store.
- Imported `Reference` type in the article store.

### How to test?

1. Generate a post using the application.
2. Verify that the generated post is displayed correctly.
3. Test the reset functionality and ensure it clears the generated post.
4. Check that the references are fetched and used properly in post generation.

### Why make this change?

This refactoring improves the separation of concerns between the composable and the store. By moving the `generatedPost` state to the composable, we reduce unnecessary coupling and make the code more maintainable. The changes also enhance type safety and make the flow of data more explicit, which can help prevent potential bugs and improve overall code quality.