### PR TITLE
✨ 다시 생성하기 기능 추가

### DIFF
--- a/src/components/LoadingComponent.vue
+++ b/src/components/LoadingComponent.vue
@@ -10,9 +10,7 @@
         animationDuration=".5s"
       />
       <div class="absolute inset-0 flex items-center justify-center">
-        <span class="text-2xl font-bold text-primary-500"
-          >{{ progressPercentage }}%</span
-        >
+        <span class="text-2xl font-bold text-primary-500">{{ progress }}%</span>
       </div>
     </div>
     <p class="mt-6 text-xl font-semibold text-primary-800">
@@ -22,7 +20,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, onMounted, onUnmounted } from "vue";
+import { defineComponent, ref, watch, onUnmounted } from "vue";
 import ProgressSpinner from "primevue/progressspinner";
 
 export default defineComponent({
@@ -30,32 +28,30 @@ export default defineComponent({
   components: { ProgressSpinner },
   props: {
     stage: {
-      type: String,
+      type: String as () => "references" | "generating" | "finalizing",
+      required: true,
+    },
+    progress: {
+      type: Number,
       required: true,
     },
   },
   setup(props) {
-    const progress = ref(0);
     const loadingMessage = ref("");
     const displayedMessage = ref("");
-    const progressPercentage = ref(0);
 
     const updateLoadingState = (stage: string) => {
       switch (stage) {
         case "references":
-          progress.value = 33;
           loadingMessage.value = "참조 자료를 수집하는 중...";
           break;
         case "generating":
-          progress.value = 66;
           loadingMessage.value = "포스트를 생성하는 중...";
           break;
         case "finalizing":
-          progress.value = 100;
           loadingMessage.value = "최종 결과를 준비하는 중...";
           break;
         default:
-          progress.value = 0;
           loadingMessage.value = "준비 중...";
       }
     };
@@ -81,38 +77,12 @@ export default defineComponent({
       startTypingEffect();
     });
 
-    // Progress animation
-    let progressInterval: number;
-    const animateProgress = () => {
-      progressInterval = window.setInterval(() => {
-        if (progressPercentage.value < progress.value) {
-          progressPercentage.value++;
-        } else {
-          clearInterval(progressInterval);
-        }
-      }, 20);
-    };
-
-    watch(progress, () => {
-      clearInterval(progressInterval);
-      animateProgress();
-    });
-
-    onMounted(() => {
-      startTypingEffect();
-      animateProgress();
-    });
-
     onUnmounted(() => {
       clearInterval(typingInterval);
-      clearInterval(progressInterval);
     });
 
     return {
-      progress,
-      loadingMessage,
       displayedMessage,
-      progressPercentage,
     };
   },
 });

--- a/src/composables/useLoadingState.ts
+++ b/src/composables/useLoadingState.ts
@@ -1,0 +1,51 @@
+import { ref, computed } from "vue";
+
+export function useLoadingState() {
+  const isLoading = ref(false);
+  const loadingStage = ref<"references" | "generating" | "finalizing">(
+    "references"
+  );
+  const error = ref("");
+
+  const progressPercentage = computed(() => {
+    switch (loadingStage.value) {
+      case "references":
+        return 33;
+      case "generating":
+        return 66;
+      case "finalizing":
+        return 100;
+      default:
+        return 0;
+    }
+  });
+
+  const setLoading = (loading: boolean) => {
+    isLoading.value = loading;
+  };
+
+  const setLoadingStage = (
+    stage: "references" | "generating" | "finalizing"
+  ) => {
+    loadingStage.value = stage;
+  };
+
+  const setError = (errorMessage: string) => {
+    error.value = errorMessage;
+  };
+
+  const resetError = () => {
+    error.value = "";
+  };
+
+  return {
+    isLoading,
+    loadingStage,
+    error,
+    progressPercentage,
+    setLoading,
+    setLoadingStage,
+    setError,
+    resetError,
+  };
+}

--- a/src/pages/ResultPage.vue
+++ b/src/pages/ResultPage.vue
@@ -2,7 +2,7 @@
   <div class="result-page">
     <Toast />
     <template v-if="isLoading">
-      <LoadingComponent :stage="loadingStage" />
+      <LoadingComponent :stage="loadingStage" :progress="progressPercentage" />
     </template>
     <template v-else-if="error">
       <Message severity="error" :closable="false" class="mb-4">{{
@@ -17,14 +17,19 @@
       <GeneratedPost :content="generatedPost" />
       <div class="flex justify-center gap-4 mt-4">
         <Button label="처음으로" @click="reset" class="p-button-secondary" />
-        <Toast position="bottom-center" group="bc" />
         <Button
           label="포스트 복사하기"
           @click="copyPost"
           class="p-button-primary"
         />
+        <Button
+          label="다시 생성하기"
+          @click="regeneratePost"
+          class="p-button-info"
+        />
       </div>
     </template>
+    <Toast position="bottom-center" group="bc" />
   </div>
 </template>
 
@@ -36,6 +41,7 @@ import Button from "primevue/button";
 import Message from "primevue/message";
 import Toast from "primevue/toast";
 import { usePostGeneration } from "../composables/usePostGeneration";
+import { useLoadingState } from "../composables/useLoadingState";
 
 export default defineComponent({
   name: "ResultPage",
@@ -49,7 +55,10 @@ export default defineComponent({
       reset,
       copyPost,
       generatePost,
+      regeneratePost,
     } = usePostGeneration();
+
+    const { progressPercentage } = useLoadingState();
 
     onMounted(generatePost);
 
@@ -60,6 +69,8 @@ export default defineComponent({
       generatedPost,
       reset,
       copyPost,
+      regeneratePost,
+      progressPercentage,
     };
   },
 });


### PR DESCRIPTION
fix #35 

### TL;DR

Refactored loading state management and improved post generation functionality.

### What changed?

- Introduced a new `useLoadingState` composable for centralized loading state management.
- Updated `LoadingComponent` to use the new loading state management.
- Enhanced `usePostGeneration` composable with improved error handling and a new `regeneratePost` function.
- Modified `ResultPage` to include a "다시 생성하기" (Regenerate) button and utilize the new loading state management.

### How to test?

1. Navigate to the Result Page.
2. Observe the loading process and verify that the progress percentage updates correctly.
3. Once the post is generated, test the new "다시 생성하기" button to ensure it regenerates the post without fetching new references.
4. Verify that error handling works correctly by simulating network errors or other failure scenarios.

### Why make this change?

This refactoring improves code organization, centralizes loading state management, and enhances the user experience by providing more control over the post generation process. The addition of the regenerate functionality allows users to create new posts using existing references, potentially saving time and resources.