### PR TITLE
🐛 enable puppeteer on vercel serverless

### DIFF
--- a/backend/modules/WebScraper.ts
+++ b/backend/modules/WebScraper.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
-import puppeteer, { Browser } from "puppeteer";
+import puppeteer, { Browser } from "puppeteer-core";
+import chromium from "@sparticuz/chromium";
 import { NAVER_ENTERTAIN_URL, NAVER_SPORTS_URL } from "../config/newsConfig.js";
 import { WebScraperError } from "../errors/WebScraperError.js";
 
@@ -26,7 +27,12 @@ export class WebScraper {
 
   private async fetchWithPuppeteer(url: string): Promise<string> {
     if (!this.browser) {
-      this.browser = await puppeteer.launch();
+      this.browser = await puppeteer.launch({
+        args: chromium.args,
+        defaultViewport: chromium.defaultViewport,
+        executablePath: await chromium.executablePath(),
+        headless: chromium.headless,
+      });
     }
     const page = await this.browser.newPage();
     try {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@langchain/openai": "^0.2.7",
+    "@sparticuz/chromium": "^127.0.0",
     "axios": "^1.7.7",
     "cheerio": "^1.0.0",
     "core-js": "^3.8.3",
@@ -17,7 +18,7 @@
     "pinia": "^2.2.2",
     "primeicons": "^7.0.0",
     "primevue": "^4.0.7",
-    "puppeteer": "^23.4.1",
+    "puppeteer-core": "^23.4.1",
     "tailwindcss": "^3.4.12",
     "tailwindcss-primeui": "^0.3.4",
     "vercel": "^37.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1348,6 +1348,14 @@
   resolved "https://registry.yarnpkg.com/@soda/get-current-script/-/get-current-script-1.0.2.tgz#a53515db25d8038374381b73af20bb4f2e508d87"
   integrity sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==
 
+"@sparticuz/chromium@^127.0.0":
+  version "127.0.0"
+  resolved "https://registry.yarnpkg.com/@sparticuz/chromium/-/chromium-127.0.0.tgz#7f93f2e67c3fa5c83b63e9b54b225f4a6db34a35"
+  integrity sha512-3YdElfXb6kqcFtlgaArNZohhZ1gWAiWg5kPYIZbaoHFau7dHZvbYg3EEjeE30bYi6cfOnB8wVpluuasF8Y3QyQ==
+  dependencies:
+    follow-redirects "^1.15.6"
+    tar-fs "^3.0.6"
+
 "@tootallnate/once@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
@@ -3401,16 +3409,6 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cosmiconfig@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-9.0.0.tgz#34c3fc58287b915f3ae905ab6dc3de258b55ad9d"
-  integrity sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==
-  dependencies:
-    env-paths "^2.2.1"
-    import-fresh "^3.3.0"
-    js-yaml "^4.1.0"
-    parse-json "^5.2.0"
-
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
@@ -3951,11 +3949,6 @@ entities@^4.2.0, entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
-
-env-paths@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
-  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -5214,7 +5207,7 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -6419,7 +6412,7 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parse-json@^5.0.0, parse-json@^5.2.0:
+parse-json@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
@@ -7043,7 +7036,7 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-puppeteer-core@23.4.1:
+puppeteer-core@^23.4.1:
   version "23.4.1"
   resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-23.4.1.tgz#c1c0367b7f48645119b65b08889b0690ea00cc1f"
   integrity sha512-uCxGtn8VE9PlKhdFJX/zZySi9K3Ufr3qUZe28jxJoZUqiMJOi+SFh2zhiFDSjWqZIDkc0FtnaCC+rewW3MYXmg==
@@ -7054,18 +7047,6 @@ puppeteer-core@23.4.1:
     devtools-protocol "0.0.1342118"
     typed-query-selector "^2.12.0"
     ws "^8.18.0"
-
-puppeteer@^23.4.1:
-  version "23.4.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-23.4.1.tgz#b2bf40eda1af4cfa7b2e3149eee682b8a050a471"
-  integrity sha512-+wWfWTkQ8L9IB/3OVGSUp37c0eQ5za/85KdX+LAq2wTZkMdocgYGMCs+/91e2f/RXIYzve4x/uGxN8zG2sj8+w==
-  dependencies:
-    "@puppeteer/browsers" "2.4.0"
-    chromium-bidi "0.6.5"
-    cosmiconfig "^9.0.0"
-    devtools-protocol "0.0.1342118"
-    puppeteer-core "23.4.1"
-    typed-query-selector "^2.12.0"
 
 qs@6.11.0:
   version "6.11.0"


### PR DESCRIPTION
### TL;DR

Switched from Puppeteer to Puppeteer-core with Chromium for improved compatibility and performance in serverless environments.

### What changed?

- Replaced `puppeteer` with `puppeteer-core` and added `@sparticuz/chromium` as a dependency.
- Updated the `WebScraper` class to use `puppeteer-core` with Chromium-specific launch options.
- Modified the browser launch configuration to use Chromium's args, default viewport, executable path, and headless mode.

### How to test?

1. Install the updated dependencies by running `yarn install` or `npm install`.
2. Verify that web scraping functionality still works as expected in both development and production environments.
3. Test the application in a serverless environment (e.g., Vercel) to ensure compatibility.

### Why make this change?

This change addresses potential issues with running Puppeteer in serverless environments. By using `puppeteer-core` with `@sparticuz/chromium`, we can ensure better compatibility and performance, especially when deploying to platforms like Vercel. This approach provides a more lightweight and optimized solution for web scraping in cloud-based environments.