### PR TITLE
✨ add news selection feature

### DIFF
--- a/src/components/LinkPreview.vue
+++ b/src/components/LinkPreview.vue
@@ -43,27 +43,20 @@ export default defineComponent({
   },
   emits: ["toggle-selection"],
   setup(props) {
-    const cleanTitle = computed(() => {
-      return props.newsItem.title
-        .replace(/<b>/g, "")
-        .replace(/<\/b>/g, "")
+    const cleanText = (text: string) => {
+      return text
+        .replace(/<\/?b>/g, "")
         .replace(/&quot;/g, '"')
         .replace(/&amp;/g, "&")
         .replace(/&lt;/g, "<")
         .replace(/&gt;/g, ">")
         .trim();
-    });
+    };
 
-    const cleanDescription = computed(() => {
-      return props.newsItem.description
-        .replace(/<b>/g, "")
-        .replace(/<\/b>/g, "")
-        .replace(/&quot;/g, '"')
-        .replace(/&amp;/g, "&")
-        .replace(/&lt;/g, "<")
-        .replace(/&gt;/g, ">")
-        .trim();
-    });
+    const cleanTitle = computed(() => cleanText(props.newsItem.title));
+    const cleanDescription = computed(() =>
+      cleanText(props.newsItem.description)
+    );
 
     return {
       cleanTitle,

--- a/src/components/LinkPreview.vue
+++ b/src/components/LinkPreview.vue
@@ -1,0 +1,46 @@
+<template>
+  <div
+    class="border rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-shadow duration-300 p-4"
+    :class="{ 'border-primary-500': selected, 'border-gray-200': !selected }"
+  >
+    <h3 class="font-bold text-lg mb-2">{{ newsItem.title }}</h3>
+    <p class="text-gray-600 text-sm mb-4">{{ newsItem.description }}</p>
+    <div class="flex justify-between items-center">
+      <a
+        :href="newsItem.link"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-primary-600 hover:text-primary-800 transition-colors duration-300"
+      >
+        자세히 보기
+      </a>
+      <Button
+        :icon="selected ? 'pi pi-check-square' : 'pi pi-square'"
+        :class="{ 'p-button-outlined': !selected }"
+        @click="$emit('toggle-selection', newsItem)"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from "vue";
+import Button from "primevue/button";
+import type { NewsItem } from "../types";
+
+export default defineComponent({
+  name: "LinkPreview",
+  components: { Button },
+  props: {
+    newsItem: {
+      type: Object as PropType<NewsItem>,
+      required: true,
+    },
+    selected: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["toggle-selection"],
+});
+</script>

--- a/src/components/LinkPreview.vue
+++ b/src/components/LinkPreview.vue
@@ -3,8 +3,8 @@
     class="border rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-shadow duration-300 p-4"
     :class="{ 'border-primary-500': selected, 'border-gray-200': !selected }"
   >
-    <h3 class="font-bold text-lg mb-2">{{ newsItem.title }}</h3>
-    <p class="text-gray-600 text-sm mb-4">{{ newsItem.description }}</p>
+    <h3 class="font-bold text-lg mb-2">{{ cleanTitle }}</h3>
+    <p class="text-gray-600 text-sm mb-4">{{ cleanDescription }}</p>
     <div class="flex justify-between items-center">
       <a
         :href="newsItem.link"
@@ -24,7 +24,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from "vue";
+import { defineComponent, PropType, computed } from "vue";
 import Button from "primevue/button";
 import type { NewsItem } from "../types";
 
@@ -42,5 +42,33 @@ export default defineComponent({
     },
   },
   emits: ["toggle-selection"],
+  setup(props) {
+    const cleanTitle = computed(() => {
+      return props.newsItem.title
+        .replace(/<b>/g, "")
+        .replace(/<\/b>/g, "")
+        .replace(/&quot;/g, '"')
+        .replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .trim();
+    });
+
+    const cleanDescription = computed(() => {
+      return props.newsItem.description
+        .replace(/<b>/g, "")
+        .replace(/<\/b>/g, "")
+        .replace(/&quot;/g, '"')
+        .replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .trim();
+    });
+
+    return {
+      cleanTitle,
+      cleanDescription,
+    };
+  },
 });
 </script>

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -14,7 +14,7 @@
     <KeywordInput
       v-if="inputMode.value === 'keyword'"
       v-model="topic"
-      @generate="generatePostFromKeyword"
+      @generate="searchNews"
     />
 
     <DirectTextInput v-else @generate="generatePostFromText" />
@@ -46,10 +46,10 @@ export default defineComponent({
     const articleStore = useArticleStore();
     const { inputModes, inputMode } = useInputMode();
 
-    const generatePostFromKeyword = async () => {
+    const searchNews = async () => {
       if (topic.value.trim()) {
         await articleStore.setTopic(topic.value.trim());
-        router.push("/result");
+        router.push("/news-selection");
       }
     };
 
@@ -68,7 +68,7 @@ export default defineComponent({
 
     return {
       topic,
-      generatePostFromKeyword,
+      searchNews,
       inputModes,
       inputMode,
       generatePostFromText,

--- a/src/pages/NewsSelectionPage.vue
+++ b/src/pages/NewsSelectionPage.vue
@@ -9,10 +9,16 @@
       {{ error }}
     </div>
     <div v-else class="flex flex-col h-[calc(100vh-200px)]">
-      <div class="flex justify-end mb-2">
+      <div class="flex justify-between items-center mb-5">
         <p class="text-sm text-gray-600">
           {{ selectedItems.length }}/{{ MAX_NEWS_ITEMS }} 선택됨
         </p>
+        <Button
+          label="포스트 생성하기"
+          icon="pi pi-file-edit"
+          @click="generatePost"
+          :disabled="selectedItems.length === 0"
+        />
       </div>
       <div class="flex-grow overflow-y-auto mb-4">
         <div class="grid grid-cols-1 gap-4">
@@ -20,27 +26,17 @@
             v-for="item in paginatedNewsItems"
             :key="item.link"
             :news-item="item"
-            :selected="selectedItems.includes(item)"
+            :selected="isSelected(item)"
             @toggle-selection="toggleSelection(item)"
           />
         </div>
       </div>
-      <div class="flex justify-between items-center mt-4">
-        <Paginator
-          v-model:first="first"
-          :rows="5"
-          :total-records="newsItems.length"
-          template="PrevPageLink PageLinks NextPageLink"
-          class="flex-grow"
-        />
-        <Button
-          label="포스트 생성하기"
-          icon="pi pi-file-edit"
-          @click="generatePost"
-          :disabled="selectedItems.length === 0"
-          class="ml-4"
-        />
-      </div>
+      <Paginator
+        v-model:first="first"
+        :rows="5"
+        :total-records="newsItems.length"
+        template="PrevPageLink PageLinks NextPageLink"
+      />
     </div>
   </div>
 </template>
@@ -74,6 +70,9 @@ export default defineComponent({
       return newsItems.value.slice(start, end);
     });
 
+    const isSelected = (item: NewsItem) =>
+      selectedItems.value.some((i) => i.link === item.link);
+
     const toggleSelection = (item: NewsItem) => {
       const index = selectedItems.value.findIndex((i) => i.link === item.link);
       if (index === -1) {
@@ -90,16 +89,18 @@ export default defineComponent({
       router.push("/result");
     };
 
-    onMounted(async () => {
+    const fetchNewsItems = async () => {
       try {
         newsItems.value = await articleStore.searchNews();
-        isLoading.value = false;
       } catch (e) {
         error.value =
           "뉴스 기사를 불러오는데 실패했습니다. 다시 시도해 주세요.";
+      } finally {
         isLoading.value = false;
       }
-    });
+    };
+
+    onMounted(fetchNewsItems);
 
     return {
       newsItems,
@@ -111,6 +112,7 @@ export default defineComponent({
       paginatedNewsItems,
       first,
       MAX_NEWS_ITEMS,
+      isSelected,
     };
   },
 });

--- a/src/pages/NewsSelectionPage.vue
+++ b/src/pages/NewsSelectionPage.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold mb-6">뉴스 선택하기</h1>
+    <div v-if="isLoading" class="text-center">
+      <ProgressSpinner />
+      <p class="mt-4">뉴스 기사를 불러오는 중...</p>
+    </div>
+    <div v-else-if="error" class="text-red-500">
+      {{ error }}
+    </div>
+    <div v-else>
+      <div class="grid grid-cols-1 gap-6 mb-6">
+        <LinkPreview
+          v-for="item in paginatedNewsItems"
+          :key="item.link"
+          :news-item="item"
+          :selected="selectedItems.includes(item)"
+          @toggle-selection="toggleSelection(item)"
+        />
+      </div>
+      <Paginator
+        v-model:first="first"
+        :rows="5"
+        :total-records="newsItems.length"
+        template="PrevPageLink PageLinks NextPageLink"
+        class="mb-6"
+      />
+      <div class="flex justify-between items-center">
+        <p class="text-sm text-gray-600">
+          {{ selectedItems.length }}/{{ MAX_NEWS_ITEMS }} 선택됨
+        </p>
+        <Button
+          label="포스트 생성하기"
+          icon="pi pi-file-edit"
+          @click="generatePost"
+          :disabled="selectedItems.length === 0"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, onMounted, ref, computed } from "vue";
+import { useRouter } from "vue-router";
+import { useArticleStore } from "../stores/articleStore";
+import LinkPreview from "../components/LinkPreview.vue";
+import Button from "primevue/button";
+import ProgressSpinner from "primevue/progressspinner";
+import Paginator from "primevue/paginator";
+import type { NewsItem } from "../types";
+import { MAX_NEWS_ITEMS } from "../../backend/config/newsConfig";
+
+export default defineComponent({
+  name: "NewsSelectionPage",
+  components: { LinkPreview, Button, ProgressSpinner, Paginator },
+  setup() {
+    const router = useRouter();
+    const articleStore = useArticleStore();
+    const newsItems = ref<NewsItem[]>([]);
+    const selectedItems = ref<NewsItem[]>([]);
+    const isLoading = ref(true);
+    const error = ref("");
+    const first = ref(0);
+
+    const paginatedNewsItems = computed(() => {
+      const start = first.value;
+      const end = start + 5;
+      return newsItems.value.slice(start, end);
+    });
+
+    const toggleSelection = (item: NewsItem) => {
+      const index = selectedItems.value.findIndex((i) => i.link === item.link);
+      if (index === -1) {
+        if (selectedItems.value.length < MAX_NEWS_ITEMS) {
+          selectedItems.value.push(item);
+        }
+      } else {
+        selectedItems.value.splice(index, 1);
+      }
+    };
+
+    const generatePost = () => {
+      articleStore.setSelectedNewsItems(selectedItems.value);
+      router.push("/result");
+    };
+
+    onMounted(async () => {
+      try {
+        newsItems.value = await articleStore.searchNews();
+        isLoading.value = false;
+      } catch (e) {
+        error.value =
+          "뉴스 기사를 불러오는데 실패했습니다. 다시 시도해 주세요.";
+        isLoading.value = false;
+      }
+    });
+
+    return {
+      newsItems,
+      selectedItems,
+      isLoading,
+      error,
+      toggleSelection,
+      generatePost,
+      paginatedNewsItems,
+      first,
+      MAX_NEWS_ITEMS,
+    };
+  },
+});
+</script>

--- a/src/pages/NewsSelectionPage.vue
+++ b/src/pages/NewsSelectionPage.vue
@@ -8,32 +8,37 @@
     <div v-else-if="error" class="text-red-500">
       {{ error }}
     </div>
-    <div v-else>
-      <div class="grid grid-cols-1 gap-6 mb-6">
-        <LinkPreview
-          v-for="item in paginatedNewsItems"
-          :key="item.link"
-          :news-item="item"
-          :selected="selectedItems.includes(item)"
-          @toggle-selection="toggleSelection(item)"
-        />
-      </div>
-      <Paginator
-        v-model:first="first"
-        :rows="5"
-        :total-records="newsItems.length"
-        template="PrevPageLink PageLinks NextPageLink"
-        class="mb-6"
-      />
-      <div class="flex justify-between items-center">
+    <div v-else class="flex flex-col h-[calc(100vh-200px)]">
+      <div class="flex justify-end mb-2">
         <p class="text-sm text-gray-600">
           {{ selectedItems.length }}/{{ MAX_NEWS_ITEMS }} 선택됨
         </p>
+      </div>
+      <div class="flex-grow overflow-y-auto mb-4">
+        <div class="grid grid-cols-1 gap-4">
+          <LinkPreview
+            v-for="item in paginatedNewsItems"
+            :key="item.link"
+            :news-item="item"
+            :selected="selectedItems.includes(item)"
+            @toggle-selection="toggleSelection(item)"
+          />
+        </div>
+      </div>
+      <div class="flex justify-between items-center mt-4">
+        <Paginator
+          v-model:first="first"
+          :rows="5"
+          :total-records="newsItems.length"
+          template="PrevPageLink PageLinks NextPageLink"
+          class="flex-grow"
+        />
         <Button
           label="포스트 생성하기"
           icon="pi pi-file-edit"
           @click="generatePost"
           :disabled="selectedItems.length === 0"
+          class="ml-4"
         />
       </div>
     </div>
@@ -110,3 +115,9 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+.container {
+  max-width: 800px;
+}
+</style>

--- a/src/pages/ResultPage.vue
+++ b/src/pages/ResultPage.vue
@@ -58,7 +58,9 @@ export default defineComponent({
       progressPercentage,
     } = usePostGeneration();
 
-    onMounted(generatePost);
+    onMounted(async () => {
+      await generatePost();
+    });
 
     return {
       isLoading,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from "vue-router";
 import HomePage from "../pages/HomePage.vue";
 import ResultPage from "../pages/ResultPage.vue";
+import NewsSelectionPage from "../pages/NewsSelectionPage.vue";
 
 const routes = [
   {
@@ -13,6 +14,11 @@ const routes = [
     name: "Result",
     component: ResultPage,
   },
+  {
+    path: "/news-selection",
+    name: "NewsSelection",
+    component: NewsSelectionPage,
+  },
 ];
 
 const router = createRouter({
@@ -21,8 +27,8 @@ const router = createRouter({
 });
 
 router.beforeEach((to, from, next) => {
-  if (to.name === "Result" && !from.name) {
-    // Prevent direct navigation to the result page
+  if ((to.name === "Result" || to.name === "NewsSelection") && !from.name) {
+    // Prevent direct navigation to the result or news selection page
     next("/");
   } else {
     next();

--- a/src/services/NewsService.ts
+++ b/src/services/NewsService.ts
@@ -1,11 +1,5 @@
 import axios from "axios";
 import type { NewsItem } from "../types";
-import {
-  NAVER_NEWS_URL,
-  NAVER_ENTERTAIN_URL,
-  NAVER_SPORTS_URL,
-  MAX_NEWS_ITEMS,
-} from "../../backend/config/newsConfig";
 
 export class NewsService {
   constructor(private apiUrl: string) {}
@@ -15,17 +9,5 @@ export class NewsService {
       `${this.apiUrl}/search-news?query=${query}`
     );
     return response.data.newsItems;
-  }
-
-  filterNewsItems(newsItems: NewsItem[]): NewsItem[] {
-    return newsItems
-      .filter((item) => this.isValidNewsUrl(item.link))
-      .slice(0, MAX_NEWS_ITEMS);
-  }
-
-  private isValidNewsUrl(url: string): boolean {
-    return [NAVER_NEWS_URL, NAVER_ENTERTAIN_URL, NAVER_SPORTS_URL].some(
-      (validUrl) => url.startsWith(validUrl)
-    );
   }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -16,6 +16,7 @@ export interface NewsItem {
   link: string;
   description: string;
   pubDate: string;
+  thumbnail?: string;
 }
 
 export interface ParsedContent {


### PR DESCRIPTION
✨ add news selection feature

- 새로운 NewsSelectionPage 컴포넌트 추가
- LinkPreview 컴포넌트 구현
- 뉴스 아이템 선택 및 페이지네이션 기능 추가
- 선택된 뉴스 아이템을 기반으로 포스트 생성 로직 수정

디테일 수정

- HomePage에서 키워드 입력 후 NewsSelectionPage로 이동하도록 변경
- ResultPage에서 선택된 뉴스 아이템을 사용하여 포스트 생성
- 라우터에 NewsSelectionPage 경로 추가 및 직접 접근 방지 로직 구현

리팩토링

- NewsService에서 필터링 로직 제거
- articleStore에서 뉴스 검색 및 참조 생성 로직 분리
- 타입 정의 업데이트 (NewsItem에 thumbnail 필드 추가)