### PR TITLE
⚡ improve scraper performance

### DIFF
--- a/backend/modules/WebScraper.ts
+++ b/backend/modules/WebScraper.ts
@@ -36,7 +36,7 @@ export class WebScraper {
     }
     const page = await this.browser.newPage();
     try {
-      await page.goto(url, { waitUntil: "networkidle0" });
+      await page.goto(url, { waitUntil: "networkidle2" });
       return await page.content();
     } finally {
       await page.close();


### PR DESCRIPTION
### TL;DR

Updated the `waitUntil` option in the `WebScraper` class to improve page load reliability.

### What changed?

Modified the `goto` method call in the `WebScraper` class, changing the `waitUntil` option from `"networkidle0"` to `"networkidle2"`.

### How to test?

1. Run the web scraper on various websites with different load times and network conditions.
2. Verify that the scraper successfully retrieves the page content without timing out prematurely.
3. Compare the results with the previous `"networkidle0"` setting to ensure improved reliability.

### Why make this change?

The `"networkidle2"` option allows for more flexibility in page load completion, considering the page as loaded when there are no more than 2 network connections for at least 500 ms. This change aims to improve the reliability of the web scraper, especially for pages with persistent network activity or long-running background requests.