### PR TITLE
✨ filter searched news

### DIFF
--- a/src/services/NewsService.ts
+++ b/src/services/NewsService.ts
@@ -1,13 +1,58 @@
 import axios from "axios";
 import type { NewsItem } from "../types";
+import {
+  NAVER_NEWS_URL,
+  NAVER_ENTERTAIN_URL,
+  NAVER_SPORTS_URL,
+} from "../../backend/config/newsConfig";
 
+/**
+ * NewsService class for handling news-related operations.
+ * This service provides methods to search and filter news items.
+ */
 export class NewsService {
+  /**
+   * Creates an instance of NewsService.
+   * @param apiUrl - The base URL for the news API.
+   */
   constructor(private apiUrl: string) {}
 
-  async searchNews(query: string): Promise<NewsItem[]> {
+  /**
+   * Searches for news items based on a given query.
+   *
+   * @param options - The options for the search query.
+   * @param options.query - The search query string.
+   * @param options.filterByDomain - Whether to filter results by specific Naver domains. Defaults to true.
+   * @returns A promise that resolves to an array of NewsItem objects.
+   *
+   * @example
+   * // Search with domain filtering (default behavior)
+   * const filteredNews = await newsService.searchNews({ query: "query" });
+   *
+   * // Search without domain filtering
+   * const allNews = await newsService.searchNews({ query: "query", filterByDomain: false });
+   */
+  async searchNews({
+    query,
+    filterByDomain = true,
+  }: {
+    query: string;
+    filterByDomain?: boolean;
+  }): Promise<NewsItem[]> {
     const response = await axios.get<{ newsItems: NewsItem[] }>(
       `${this.apiUrl}/search-news?query=${query}`
     );
+
+    if (filterByDomain) {
+      // Filter news items based on allowed domains
+      return response.data.newsItems.filter(
+        (item) =>
+          item.link.startsWith(NAVER_NEWS_URL) ||
+          item.link.startsWith(NAVER_ENTERTAIN_URL) ||
+          item.link.startsWith(NAVER_SPORTS_URL)
+      );
+    }
+
     return response.data.newsItems;
   }
 }

--- a/src/stores/articleStore.ts
+++ b/src/stores/articleStore.ts
@@ -28,7 +28,10 @@ export const useArticleStore = defineStore("article", {
         throw new Error("Topic is not set");
       }
       const newsService = new NewsService(API_URL);
-      return await newsService.searchNews(this.topic);
+      return await newsService.searchNews({
+        query: this.topic,
+        filterByDomain: true,
+      });
     },
     async getReferences(): Promise<Reference[]> {
       if (this.selectedNewsItems.length > 0) {


### PR DESCRIPTION
### TL;DR

Enhanced NewsService with domain filtering and improved search functionality.

### What changed?

- Added domain filtering to NewsService's searchNews method
- Introduced new configuration constants for Naver news URLs
- Updated searchNews method to accept an options object with query and filterByDomain parameters
- Implemented filtering logic to restrict results to specific Naver domains
- Updated articleStore to use the new searchNews method signature

### How to test?

1. Call `searchNews` with default options to verify domain filtering:
   ```typescript
   const filteredNews = await newsService.searchNews({ query: "test query" });
   ```
2. Call `searchNews` without domain filtering:
   ```typescript
   const allNews = await newsService.searchNews({ query: "test query", filterByDomain: false });
   ```
3. Verify that the filtered results only contain news items from the specified Naver domains
4. Check that the unfiltered results include news items from all domains

### Why make this change?

This change improves the quality and relevance of search results by focusing on specific Naver domains. It also provides more flexibility in the search functionality, allowing users to opt-out of domain filtering when needed. The enhanced NewsService class with improved documentation makes it easier for developers to understand and use the search functionality.