### PR TITLE
🐛 fix InputMode selectbutton

### DIFF
--- a/src/composables/useInputMode.ts
+++ b/src/composables/useInputMode.ts
@@ -1,16 +1,18 @@
 import { ref } from "vue";
 
-interface InputMode {
+type InputModeValue = "keyword" | "text";
+
+interface InputModeOption {
   name: string;
-  value: "keyword" | "text";
+  value: InputModeValue;
 }
 
 export function useInputMode() {
-  const inputModes = ref<InputMode[]>([
+  const inputModes = ref<InputModeOption[]>([
     { name: "키워드로 생성하기", value: "keyword" },
     { name: "직접 텍스트 입력하기", value: "text" },
   ]);
-  const inputMode = ref<InputMode>(inputModes.value[0]);
+  const inputMode = ref<InputModeValue>("keyword");
 
   return {
     inputModes,

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -8,11 +8,13 @@
       v-model="inputMode"
       :options="inputModes"
       optionLabel="name"
+      optionValue="value"
       class="mb-4"
+      :allowEmpty="false"
     />
 
     <KeywordInput
-      v-if="inputMode.value === 'keyword'"
+      v-if="inputMode === 'keyword'"
       v-model="topic"
       @generate="searchNews"
     />
@@ -58,12 +60,10 @@ export default defineComponent({
       router.push("/result");
     };
 
-    const inputModeDescription = computed(
-      () =>
-        ({
-          keyword: "관련 뉴스를 찾아 포스트를 생성해드려요 ☺️",
-          text: "입력한 텍스트를 기반으로 포스트를 생성해드려요 ☺️",
-        }[inputMode.value.value])
+    const inputModeDescription = computed(() =>
+      inputMode.value === "keyword"
+        ? "관련 뉴스를 찾아 포스트를 생성해드려요 ☺️"
+        : "입력한 텍스트를 기반으로 포스트를 생성해드려요 ☺️"
     );
 
     return {


### PR DESCRIPTION
### TL;DR

Refactored input mode handling and improved type safety in the HomePage component.

### What changed?

- Updated `useInputMode` composable:
  - Introduced `InputModeValue` type
  - Renamed `InputMode` interface to `InputModeOption`
  - Changed `inputMode` ref to use `InputModeValue` type instead of `InputModeOption`
- Modified HomePage component:
  - Updated `v-select` component props
  - Adjusted `v-if` condition for `KeywordInput` component
  - Simplified `inputModeDescription` computed property

### How to test?

1. Navigate to the HomePage
2. Verify that the input mode selector works correctly
3. Ensure that the appropriate input component (KeywordInput or TextInput) is displayed based on the selected mode
4. Check that the input mode description updates correctly when switching between modes

### Why make this change?

This change improves type safety and simplifies the input mode handling logic. By using a more specific type for the input mode value, we reduce the potential for errors and make the code more maintainable. The refactoring also enhances the readability of the HomePage component by simplifying the conditional rendering and computed property logic.

inputMode가 객체(InputMode)를 참조하고 있기 때문에, SelectButton에서 선택을 변경할 때마다 새로운 객체를 생성하게 됩니다. 이는 Vue의 반응성 시스템에서 객체의 참조 변경으로 인식되어, 관련된 컴포넌트들이 다시 렌더링되거나 마운트됩니다. 특히 v-if로 제어되는 컴포넌트(KeywordInput, DirectTextInput)가 언마운트되고 다시 마운트되면서 라이프사이클 훅(onMounted)이 올바르지 않은 시점에 호출되어 에러가 발생합니다.