### PR TITLE
✨ 기존 게시글 추가/관리 기능 구현

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,1 +1,2 @@
 src/presets/
+reusable-prompt.md

--- a/backend/prompts/CreateComposedPrompt.ts
+++ b/backend/prompts/CreateComposedPrompt.ts
@@ -16,7 +16,7 @@ export function createComposedPrompt({
 } = {}) {
   const finalIntroduction = introduction || defaultContent.introduction;
   const finalGuideline = guideline || defaultContent.guideline;
-  const finalExamples = examples || defaultContent.examples;
+  const finalExamples = examples?.length ? examples : defaultContent.examples;
 
   const introductionPrompt = formatIntroduction(finalIntroduction);
   const guidelinesPrompt = formatGuideline(finalGuideline);

--- a/src/components/ExampleModal.vue
+++ b/src/components/ExampleModal.vue
@@ -1,0 +1,83 @@
+<template>
+  <Dialog
+    :visible="visible"
+    :style="{ width: '50vw' }"
+    :modal="true"
+    :closable="false"
+    :header="isEditing ? '게시글 예시 수정' : '게시글 예시 등록'"
+  >
+    <div class="p-fluid">
+      <div class="field">
+        <label for="content">내용</label>
+        <Textarea id="content" v-model="content" rows="5" autoResize />
+      </div>
+    </div>
+    <template #footer>
+      <Button
+        label="취소"
+        icon="pi pi-times"
+        @click="close"
+        class="p-button-text"
+      />
+      <Button label="저장" icon="pi pi-check" @click="save" autofocus />
+    </template>
+  </Dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, watch } from "vue";
+import Dialog from "primevue/dialog";
+import Button from "primevue/button";
+import Textarea from "primevue/textarea";
+
+export default defineComponent({
+  name: "ExampleModal",
+  components: {
+    Dialog,
+    Button,
+    Textarea,
+  },
+  props: {
+    visible: {
+      type: Boolean,
+      required: true,
+    },
+    initialContent: {
+      type: String,
+      default: "",
+    },
+    isEditing: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["update:visible", "save"],
+  setup(props, { emit }) {
+    const content = ref(props.initialContent);
+
+    watch(
+      () => props.visible,
+      (newVisible) => {
+        if (newVisible) {
+          content.value = props.initialContent;
+        }
+      }
+    );
+
+    const close = () => {
+      emit("update:visible", false);
+    };
+
+    const save = () => {
+      emit("save", content.value);
+      close();
+    };
+
+    return {
+      content,
+      close,
+      save,
+    };
+  },
+});
+</script>

--- a/src/components/ExampleModal.vue
+++ b/src/components/ExampleModal.vue
@@ -1,25 +1,33 @@
 <template>
   <Dialog
     :visible="visible"
-    :style="{ width: '50vw' }"
+    :style="{ width: '90%', maxWidth: '600px' }"
     :modal="true"
     :closable="false"
     :header="isEditing ? '게시글 예시 수정' : '게시글 예시 등록'"
   >
-    <div class="p-fluid">
+    <div class="p-fluid p-4">
       <div class="field">
-        <label for="content">내용</label>
-        <Textarea id="content" v-model="content" rows="5" autoResize />
+        <label for="content" class="font-bold mb-2 block">내용</label>
+        <Textarea
+          id="content"
+          v-model="content"
+          rows="8"
+          autoResize
+          class="w-full"
+        />
       </div>
     </div>
     <template #footer>
-      <Button
-        label="취소"
-        icon="pi pi-times"
-        @click="close"
-        class="p-button-text"
-      />
-      <Button label="저장" icon="pi pi-check" @click="save" autofocus />
+      <div class="flex justify-between w-full px-4 pb-4">
+        <Button
+          label="취소"
+          icon="pi pi-times"
+          @click="close"
+          class="p-button-text"
+        />
+        <Button label="저장" icon="pi pi-check" @click="save" autofocus />
+      </div>
     </template>
   </Dialog>
 </template>

--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -28,6 +28,13 @@ export default defineComponent({
 
     const items = [
       {
+        label: "예시 관리",
+        icon: "pi pi-list",
+        command: () => {
+          router.push("/examples");
+        },
+      },
+      {
         label: "로그아웃",
         icon: "pi pi-sign-out",
         command: async () => {

--- a/src/composables/usePostGeneration.ts
+++ b/src/composables/usePostGeneration.ts
@@ -1,13 +1,17 @@
 import { ref } from "vue";
 import { useRouter } from "vue-router";
 import { useArticleStore } from "../stores/articleStore";
+import { useExampleStore } from "../stores/exampleStore";
+import { useUserStore } from "../stores/userStore";
 import { useToast } from "primevue/usetoast";
 import { useLoadingState } from "./useLoadingState";
-import type { Reference } from "../types";
+import type { Reference, PostExample } from "../types";
 
 export function usePostGeneration() {
   const router = useRouter();
   const articleStore = useArticleStore();
+  const exampleStore = useExampleStore();
+  const userStore = useUserStore();
   const toast = useToast();
   const {
     isLoading,
@@ -22,6 +26,7 @@ export function usePostGeneration() {
 
   const generatedPost = ref("");
   const references = ref<Reference[]>([]);
+  const examples = ref<PostExample[]>([]);
 
   const reset = () => {
     articleStore.setTopic("");
@@ -54,8 +59,15 @@ export function usePostGeneration() {
         references.value = await articleStore.getReferences();
       }
 
+      if (userStore.isLoggedIn && userStore.user) {
+        examples.value = await exampleStore.fetchExamples(userStore.user.id);
+      }
+
       setLoadingStage("generating");
-      generatedPost.value = await articleStore.createPost(references.value);
+      generatedPost.value = await articleStore.createPost(
+        references.value,
+        examples.value
+      );
 
       setLoadingStage("finalizing");
       await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/src/pages/ExamplesDashboardPage.vue
+++ b/src/pages/ExamplesDashboardPage.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="card">
+    <DataTable :value="examples" responsiveLayout="scroll">
+      <Column field="content" header="내용">
+        <template #body="slotProps">
+          <div class="truncate max-w-md">{{ slotProps.data.content }}</div>
+        </template>
+      </Column>
+      <Column :exportable="false" style="min-width: 8rem">
+        <template #body="slotProps">
+          <Button
+            icon="pi pi-pencil"
+            class="p-button-rounded p-button-success mr-2"
+            @click="editExample(slotProps.data)"
+          />
+          <Button
+            icon="pi pi-trash"
+            class="p-button-rounded p-button-warning"
+            @click="deleteExample(slotProps.data.id)"
+          />
+        </template>
+      </Column>
+    </DataTable>
+    <Button
+      label="새 예시 추가"
+      icon="pi pi-plus"
+      class="mt-4"
+      @click="openAddModal"
+    />
+    <ExampleModal
+      v-model:visible="modalVisible"
+      :initial-content="selectedExample.content"
+      :is-editing="isEditing"
+      @save="saveExample"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted, computed } from "vue";
+import { useExampleStore } from "@/stores/exampleStore";
+import { useUserStore } from "@/stores/userStore";
+import DataTable from "primevue/datatable";
+import Column from "primevue/column";
+import Button from "primevue/button";
+import ExampleModal from "@/components/ExampleModal.vue";
+import type { PostExample } from "@/types";
+
+export default defineComponent({
+  name: "ExamplesDashboard",
+  components: {
+    DataTable,
+    Column,
+    Button,
+    ExampleModal,
+  },
+  setup() {
+    const exampleStore = useExampleStore();
+    const userStore = useUserStore();
+    const modalVisible = ref(false);
+    const selectedExample = ref<PostExample>({
+      id: "",
+      user_id: "",
+      content: "",
+      created_at: "",
+      updated_at: "",
+    });
+    const isEditing = ref(false);
+
+    const examples = computed(() => exampleStore.examples);
+
+    onMounted(async () => {
+      if (userStore.user) {
+        await exampleStore.fetchExamples(userStore.user.id);
+      }
+    });
+
+    const openAddModal = () => {
+      selectedExample.value = {
+        id: "",
+        user_id: "",
+        content: "",
+        created_at: "",
+        updated_at: "",
+      };
+      isEditing.value = false;
+      modalVisible.value = true;
+    };
+
+    const editExample = (example: PostExample) => {
+      selectedExample.value = { ...example };
+      isEditing.value = true;
+      modalVisible.value = true;
+    };
+
+    const saveExample = async (content: string) => {
+      if (userStore.user) {
+        if (isEditing.value) {
+          await exampleStore.updateExample(selectedExample.value.id, content);
+        } else {
+          await exampleStore.addExample(userStore.user.id, content);
+        }
+        modalVisible.value = false;
+      }
+    };
+
+    const deleteExample = async (id: string) => {
+      await exampleStore.deleteExample(id);
+    };
+
+    return {
+      examples,
+      modalVisible,
+      selectedExample,
+      isEditing,
+      openAddModal,
+      editExample,
+      saveExample,
+      deleteExample,
+    };
+  },
+});
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import ResultPage from "@/pages/ResultPage.vue";
 import NewsSelectionPage from "@/pages/NewsSelectionPage.vue";
 import SignInPage from "@/pages/SignInPage.vue";
 import SignUpPage from "@/pages/SignUpPage.vue";
+import ExamplesDashboard from "@/pages/ExamplesDashboardPage.vue";
 import { useUserStore } from "@/stores/userStore";
 
 const routes = [
@@ -34,6 +35,12 @@ const routes = [
     name: "SignUp",
     component: SignUpPage,
   },
+  {
+    path: "/examples",
+    name: "Examples",
+    component: ExamplesDashboard,
+    meta: { requiresAuth: true },
+  },
 ];
 
 const router = createRouter({
@@ -41,9 +48,15 @@ const router = createRouter({
   routes,
 });
 
+let isInitialLoad = true;
+
 router.beforeEach(async (to, from, next) => {
   const userStore = useUserStore();
-  await userStore.fetchUser();
+
+  if (isInitialLoad) {
+    await userStore.fetchUser();
+    isInitialLoad = false;
+  }
 
   const requiresAuth = to.matched.some((record) => record.meta.requiresAuth);
   const isLoggedIn = userStore.isLoggedIn;

--- a/src/services/ExampleService.ts
+++ b/src/services/ExampleService.ts
@@ -1,0 +1,44 @@
+import { supabase } from "@/supabase";
+import type { PostExample } from "@/types";
+
+export class ExampleService {
+  async getExamples(userId: string): Promise<PostExample[]> {
+    const { data, error } = await supabase
+      .from("post_examples")
+      .select("*")
+      .eq("user_id", userId);
+
+    if (error) throw error;
+    return data;
+  }
+
+  async addExample(userId: string, content: string): Promise<PostExample> {
+    const { data, error } = await supabase
+      .from("post_examples")
+      .insert({ user_id: userId, content })
+      .single();
+
+    if (error) throw error;
+    return data;
+  }
+
+  async updateExample(id: string, content: string): Promise<PostExample> {
+    const { data, error } = await supabase
+      .from("post_examples")
+      .update({ content })
+      .eq("id", id)
+      .single();
+
+    if (error) throw error;
+    return data;
+  }
+
+  async deleteExample(id: string): Promise<void> {
+    const { error } = await supabase
+      .from("post_examples")
+      .delete()
+      .eq("id", id);
+
+    if (error) throw error;
+  }
+}

--- a/src/services/PostGenerationService.ts
+++ b/src/services/PostGenerationService.ts
@@ -1,12 +1,19 @@
 import axios from "axios";
-import type { Reference } from "../types";
+import type { Example, Reference } from "@/types";
 
 export class PostGenerationService {
   constructor(private apiUrl: string) {}
 
-  async generatePost(references: Reference[]): Promise<string> {
+  async generatePost({
+    references,
+    examples,
+  }: {
+    references: Reference[];
+    examples: Example[];
+  }): Promise<string> {
     const response = await axios.post(`${this.apiUrl}/generate-post`, {
       references,
+      examples,
     });
     return response.data.result;
   }

--- a/src/stores/articleStore.ts
+++ b/src/stores/articleStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import type { NewsItem, Reference } from "../types";
+import type { NewsItem, Reference, Example, PostExample } from "../types";
 import { NewsService } from "../services/NewsService";
 import { ContentParserService } from "../services/ContentParserService";
 import { PostGenerationService } from "../services/PostGenerationService";
@@ -56,10 +56,20 @@ export const useArticleStore = defineStore("article", {
     getReferencesFromDirectTexts(): Reference[] {
       return this.directTexts.map((text) => ({ text }));
     },
-    async createPost(references: Reference[]): Promise<string> {
+    async createPost(
+      references: Reference[],
+      examples: PostExample[]
+    ): Promise<string> {
       const postGenerationService = new PostGenerationService(API_URL);
+      const formattedExamples: Example[] = examples.map((example) => ({
+        text: example.content,
+      }));
+
       try {
-        return await postGenerationService.generatePost(references);
+        return await postGenerationService.generatePost({
+          references,
+          examples: formattedExamples,
+        });
       } catch (error) {
         console.error("Failed to create post:", error);
         throw new Error("포스트 생성에 실패했습니다.");

--- a/src/stores/exampleStore.ts
+++ b/src/stores/exampleStore.ts
@@ -1,0 +1,32 @@
+import { defineStore } from "pinia";
+import { ExampleService } from "@/services/ExampleService";
+import type { PostExample } from "@/types";
+
+const exampleService = new ExampleService();
+
+export const useExampleStore = defineStore("example", {
+  state: () => ({
+    examples: [] as PostExample[],
+  }),
+  actions: {
+    async fetchExamples(userId: string): Promise<PostExample[]> {
+      this.examples = await exampleService.getExamples(userId);
+      return this.examples;
+    },
+    async addExample(userId: string, content: string) {
+      const newExample = await exampleService.addExample(userId, content);
+      this.examples.push(newExample);
+    },
+    async updateExample(id: string, content: string) {
+      const updatedExample = await exampleService.updateExample(id, content);
+      const index = this.examples.findIndex((e) => e.id === id);
+      if (index !== -1) {
+        this.examples[index] = updatedExample;
+      }
+    },
+    async deleteExample(id: string) {
+      await exampleService.deleteExample(id);
+      this.examples = this.examples.filter((e) => e.id !== id);
+    },
+  },
+});

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,6 +2,10 @@ export interface Reference {
   text: string;
 }
 
+export interface Example {
+  text: string;
+}
+
 export interface NewsResponse {
   lastBuildDate: string;
   total: number;
@@ -28,3 +32,11 @@ export type LoadingStage =
   | "references"
   | "generating"
   | "finalizing";
+
+export interface PostExample {
+  id: string;
+  user_id: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
✨ 기존 게시글 추가/관리 기능 구현

- 사용자가 생성된 게시글을 예시로 저장할 수 있는 기능 추가
- 예시 관리 대시보드 페이지 구현
- 예시 추가, 수정, 삭제 기능 구현
- 저장된 예시를 게시글 생성 시 활용하도록 개선
- 사용자 메뉴에 예시 관리 링크 추가
- 인증된 사용자만 예시 관리 기능에 접근 가능하도록 설정

스타일 조정
- 예시 관리 모달 및 버튼 스타일링
- 결과 페이지에 예시 저장 버튼 추가