### PR TITLE
💄 ResultPage 요소 정리

### DIFF
--- a/src/pages/ResultPage.vue
+++ b/src/pages/ResultPage.vue
@@ -8,12 +8,11 @@
       <Message severity="error" :closable="false" class="mb-4">{{
         error
       }}</Message>
-      <Button label="다시 시도하기" @click="reset" class="mt-4" />
+      <Button label="처음으로 돌아가기" @click="goToHome" class="mt-4" />
     </template>
     <template v-else>
       <GeneratedPost :content="generatedPost" />
       <div class="flex justify-center gap-4 mt-4">
-        <Button label="처음으로" @click="reset" class="p-button-secondary" />
         <Button
           label="포스트 복사하기"
           @click="copyPost"
@@ -24,34 +23,17 @@
           @click="regeneratePost"
           class="p-button-info"
         />
-        <Button
-          v-if="isLoggedIn"
-          label="게시글 예시 등록"
-          icon="pi pi-plus"
-          @click="openExampleModal"
-          class="p-button-success"
-        />
       </div>
-      <p v-if="isLoggedIn" class="text-center mt-4 text-sm text-gray-600">
-        우상단의 "예시 관리" 버튼을 클릭하여 언제든지 예시를 관리할 수 있습니다.
-      </p>
     </template>
-    <ExampleModal
-      v-model:visible="exampleModalVisible"
-      :initial-content="generatedPost"
-      @save="saveExample"
-    />
     <Toast position="bottom-center" group="bc" />
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, computed } from "vue";
-import { useUserStore } from "../stores/userStore";
-import { useExampleStore } from "../stores/exampleStore";
+import { defineComponent, onMounted } from "vue";
+import { useRouter } from "vue-router";
 import GeneratedPost from "../components/GeneratedPost.vue";
 import LoadingComponent from "../components/LoadingComponent.vue";
-import ExampleModal from "../components/ExampleModal.vue";
 import Button from "primevue/button";
 import Message from "primevue/message";
 import Toast from "primevue/toast";
@@ -65,46 +47,26 @@ export default defineComponent({
     Button,
     Message,
     Toast,
-    ExampleModal,
   },
   setup() {
-    const userStore = useUserStore();
-    const exampleStore = useExampleStore();
-    const exampleModalVisible = ref(false);
-
+    const router = useRouter();
     const {
       isLoading,
       loadingStage,
       error,
       generatedPost,
-      reset,
       copyPost,
       generatePost,
       regeneratePost,
       progressPercentage,
     } = usePostGeneration();
 
-    const isLoggedIn = computed(() => userStore.isLoggedIn);
-
     onMounted(async () => {
       await generatePost();
     });
 
-    const openExampleModal = () => {
-      exampleModalVisible.value = true;
-    };
-
-    const saveExample = async (content: string) => {
-      if (isLoggedIn.value) {
-        await exampleStore.addExample(userStore.user!.id, content);
-        // Show success message
-        Toast.add({
-          severity: "success",
-          summary: "성공",
-          detail: "게시글 예시가 저장되었습니다.",
-          life: 3000,
-        });
-      }
+    const goToHome = () => {
+      router.push("/");
     };
 
     return {
@@ -112,14 +74,10 @@ export default defineComponent({
       loadingStage,
       error,
       generatedPost,
-      reset,
       copyPost,
       regeneratePost,
       progressPercentage,
-      isLoggedIn,
-      exampleModalVisible,
-      openExampleModal,
-      saveExample,
+      goToHome,
     };
   },
 });


### PR DESCRIPTION
### TL;DR

Simplified the ResultPage component by removing user-specific features and streamlining the UI.

### What changed?

- Removed the "다시 시도하기" (Try Again) button and replaced it with "처음으로 돌아가기" (Go Back to Home) button
- Eliminated the "처음으로" (To Beginning) button
- Removed the "게시글 예시 등록" (Register Post Example) button and related functionality
- Removed the ExampleModal component and its associated logic
- Removed user authentication checks and example management features
- Simplified the component's setup by removing unused stores and components

### How to test?

1. Navigate to the ResultPage
2. Verify that the "처음으로 돌아가기" (Go Back to Home) button is present and functional
3. Ensure that the "포스트 복사하기" (Copy Post) and "다시 생성하기" (Regenerate) buttons are still present and working
4. Confirm that there are no user-specific features or example management options visible

### Why make this change?

This change simplifies the ResultPage component, making it more focused on its core functionality of displaying and managing generated posts. By removing user-specific features and example management, the component becomes more streamlined and easier to maintain. This change also improves the user experience by providing a clear path back to the home page, rather than offering multiple reset options.