### PR TITLE
🚸 show toast for signin/up failure

### DIFF
--- a/src/composables/useToast.ts
+++ b/src/composables/useToast.ts
@@ -1,0 +1,26 @@
+import { useToast as usePrimeVueToast } from "primevue/usetoast";
+
+export function useToast() {
+  const toast = usePrimeVueToast();
+
+  const showToast = (
+    severity: "success" | "info" | "warn" | "error" | "secondary" | "contrast",
+    summary: string,
+    detail: string
+  ) => {
+    toast.add({ severity, summary, detail, life: 3000 });
+  };
+
+  const showSuccess = (message: string) => {
+    showToast("success", "성공", message);
+  };
+
+  const showError = (message: string) => {
+    showToast("error", "오류", message);
+  };
+
+  return {
+    showSuccess,
+    showError,
+  };
+}

--- a/src/pages/SignInPage.vue
+++ b/src/pages/SignInPage.vue
@@ -1,24 +1,30 @@
 <template>
-  <AuthForm
-    title="로그인"
-    submitLabel="로그인"
-    footerLink="/signup"
-    footerText="계정이 없으신가요? 회원가입"
-    @submit="handleSignIn"
-  />
+  <div>
+    <AuthForm
+      title="로그인"
+      submitLabel="로그인"
+      footerLink="/signup"
+      footerText="계정이 없으신가요? 회원가입"
+      @submit="handleSignIn"
+    />
+    <Toast position="top-right" />
+  </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
 import { useRouter } from "vue-router";
 import { useUserStore } from "../stores/userStore";
+import { useToast } from "../composables/useToast";
 import AuthForm from "@/components/AuthForm.vue";
+import Toast from "primevue/toast";
 
 export default defineComponent({
-  components: { AuthForm },
+  components: { AuthForm, Toast },
   setup() {
     const router = useRouter();
     const userStore = useUserStore();
+    const { showError } = useToast();
 
     const handleSignIn = async ({
       email,
@@ -32,7 +38,7 @@ export default defineComponent({
         router.push("/");
       } catch (error) {
         console.error("Sign in failed:", error);
-        // TODO: Show error message to user
+        showError("로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.");
       }
     };
 

--- a/src/pages/SignUpPage.vue
+++ b/src/pages/SignUpPage.vue
@@ -1,24 +1,30 @@
 <template>
-  <AuthForm
-    title="회원가입"
-    submitLabel="회원가입"
-    footerLink="/signin"
-    footerText="이미 계정이 있으신가요? 로그인"
-    @submit="handleSignUp"
-  />
+  <div>
+    <AuthForm
+      title="회원가입"
+      submitLabel="회원가입"
+      footerLink="/signin"
+      footerText="이미 계정이 있으신가요? 로그인"
+      @submit="handleSignUp"
+    />
+    <Toast position="top-right" />
+  </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
 import { useRouter } from "vue-router";
 import { useUserStore } from "../stores/userStore";
+import { useToast } from "../composables/useToast";
 import AuthForm from "@/components/AuthForm.vue";
+import Toast from "primevue/toast";
 
 export default defineComponent({
-  components: { AuthForm },
+  components: { AuthForm, Toast },
   setup() {
     const router = useRouter();
     const userStore = useUserStore();
+    const { showError } = useToast();
 
     const handleSignUp = async ({
       email,
@@ -32,7 +38,9 @@ export default defineComponent({
         router.push("/");
       } catch (error) {
         console.error("Sign up failed:", error);
-        // TODO: Show error message to user
+        showError(
+          "회원가입에 실패했습니다. 문제가 계속되면 관리자에게 문의해주세요."
+        );
       }
     };
 


### PR DESCRIPTION
### TL;DR

Implemented toast notifications for sign-in and sign-up processes.

### What changed?

- Created a new `useToast` composable to manage toast notifications.
- Added toast functionality to SignInPage and SignUpPage.
- Integrated PrimeVue Toast component in both pages.
- Implemented error handling with toast messages for failed sign-in and sign-up attempts.

### How to test?

1. Attempt to sign in with incorrect credentials and verify that an error toast appears.
2. Try to sign up with invalid information and check if an error toast is displayed.
3. Ensure that the toast messages are visible at the top-right corner of the screen.
4. Verify that the toast messages disappear after 3 seconds.

### Why make this change?

This change enhances user experience by providing immediate feedback on authentication actions. It informs users about the success or failure of their sign-in and sign-up attempts, improving the overall usability of the application.