### PR TITLE
♻️ inline style

### DIFF
--- a/src/pages/NewsSelectionPage.vue
+++ b/src/pages/NewsSelectionPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container mx-auto px-4 py-8 min-h-screen flex flex-col">
+  <div class="container mx-auto px-4 py-8 min-h-screen flex flex-col max-w-3xl">
     <h1 class="text-3xl font-bold mb-6">뉴스 선택하기</h1>
     <div v-if="isLoading" class="flex-grow flex items-center justify-center">
       <div class="text-center">
@@ -119,9 +119,3 @@ export default defineComponent({
   },
 });
 </script>
-
-<style scoped>
-.container {
-  max-width: 800px;
-}
-</style>


### PR DESCRIPTION
### TL;DR

Adjusted the layout of the NewsSelectionPage component for improved responsiveness.

### What changed?

- Added a `max-w-3xl` class to the main container div in the template.
- Removed the scoped style block that previously set a fixed `max-width` of 800px.

### How to test?

1. Navigate to the NewsSelectionPage in various screen sizes.
2. Verify that the content is responsive and properly constrained to a maximum width of 3xl (768px) on larger screens.
3. Ensure the layout looks good on both mobile and desktop views.

### Why make this change?

This change improves the responsiveness of the NewsSelectionPage component by using Tailwind's utility classes instead of custom CSS. The `max-w-3xl` class provides a more flexible maximum width that adapts better to different screen sizes while maintaining readability on larger displays.