### PR TITLE
💄 modify resultpage layout

### DIFF
--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -1,8 +1,8 @@
 @import "primeicons/primeicons.css";
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
 
 @font-face {
   font-family: "S-CoreDream-3Light";

--- a/src/pages/ResultPage.vue
+++ b/src/pages/ResultPage.vue
@@ -11,18 +11,20 @@
       <Button label="처음으로 돌아가기" @click="goToHome" class="mt-4" />
     </template>
     <template v-else>
-      <GeneratedPost :content="generatedPost" />
-      <div class="flex justify-center gap-4 mt-4">
-        <Button
-          label="포스트 복사하기"
-          @click="copyPost"
-          class="p-button-primary"
-        />
-        <Button
-          label="다시 생성하기"
-          @click="regeneratePost"
-          class="p-button-info"
-        />
+      <div class="container mx-auto px-4 py-8">
+        <GeneratedPost :content="generatedPost" />
+        <div class="flex justify-center gap-4 mt-8">
+          <Button
+            label="다시 생성하기"
+            @click="regeneratePost"
+            class="p-button-info"
+          />
+          <Button
+            label="포스트 복사하기"
+            @click="copyPost"
+            class="p-button-primary"
+          />
+        </div>
       </div>
     </template>
     <Toast position="bottom-center" group="bc" />


### PR DESCRIPTION
### TL;DR

Updated Tailwind CSS imports and improved the layout of the ResultPage component.

### What changed?

- Modified the Tailwind CSS imports in `global.css` to use `@import` statements instead of `@tailwind` directives.
- Restructured the ResultPage component layout:
  - Added a container with padding and margin.
  - Reordered the "다시 생성하기" (Regenerate) and "포스트 복사하기" (Copy Post) buttons.
  - Increased the vertical spacing between the generated post and the buttons.

### How to test?

1. Navigate to the ResultPage in the application.
2. Verify that the layout is centered and has appropriate padding.
3. Check that the "다시 생성하기" button appears before the "포스트 복사하기" button.
4. Ensure that the spacing between the generated post and the buttons is increased.
5. Confirm that the Tailwind CSS styles are still applied correctly throughout the application.

### Why make this change?

The changes aim to improve the user interface and maintainability of the code:

1. Using `@import` statements for Tailwind CSS allows for better control over the order of CSS imports.
2. The updated layout in ResultPage provides a more consistent and visually appealing design.
3. Reordering the buttons puts the primary action ("다시 생성하기") first, improving user flow.
4. Increased spacing enhances readability and visual separation between elements.