### PR TITLE
💄 modify ExamplesDashboard layout

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { createApp } from "vue";
 import PrimeVue from "primevue/config";
 import ToastService from "primevue/toastservice";
+import ConfirmationService from "primevue/confirmationservice";
 import App from "./App.vue";
 import router from "./router";
 import { createPinia } from "pinia";
@@ -16,4 +17,5 @@ app.use(PrimeVue, {
   pt: Lara,
 });
 app.use(ToastService);
+app.use(ConfirmationService);
 app.mount("#app");

--- a/src/pages/ExamplesDashboardPage.vue
+++ b/src/pages/ExamplesDashboardPage.vue
@@ -1,32 +1,49 @@
 <template>
-  <div class="card">
-    <DataTable :value="examples" responsiveLayout="scroll">
-      <Column field="content" header="내용">
-        <template #body="slotProps">
-          <div class="truncate max-w-md">{{ slotProps.data.content }}</div>
-        </template>
-      </Column>
-      <Column :exportable="false" style="min-width: 8rem">
-        <template #body="slotProps">
+  <div class="container mx-auto px-4 py-8 min-h-screen flex flex-col max-w-3xl">
+    <h1 class="text-3xl font-bold mb-6">게시글 예시 관리</h1>
+
+    <div class="mb-8 flex justify-end">
+      <Button
+        label="새 예시 추가"
+        icon="pi pi-plus"
+        @click="openAddModal"
+        class="p-button-primary"
+      />
+    </div>
+
+    <div v-if="examples.length === 0" class="text-center text-gray-500 my-8">
+      예시가 없습니다. 새로운 예시를 추가해보세요!
+    </div>
+
+    <div v-else class="space-y-4">
+      <Panel
+        v-for="(example, index) in examples"
+        :key="example.id"
+        :header="`예시 #${index + 1}`"
+        :toggleable="true"
+        class="mb-2"
+      >
+        <template #icons>
           <Button
             icon="pi pi-pencil"
-            class="p-button-rounded p-button-success mr-2"
-            @click="editExample(slotProps.data)"
+            text
+            rounded
+            aria-label="Edit"
+            @click.stop="editExample(example)"
           />
           <Button
             icon="pi pi-trash"
-            class="p-button-rounded p-button-warning"
-            @click="deleteExample(slotProps.data.id)"
+            severity="danger"
+            text
+            rounded
+            aria-label="Delete"
+            @click.stop="deleteExample(example.id)"
           />
         </template>
-      </Column>
-    </DataTable>
-    <Button
-      label="새 예시 추가"
-      icon="pi pi-plus"
-      class="mt-4"
-      @click="openAddModal"
-    />
+        <p class="whitespace-pre-wrap text-sm">{{ example.content }}</p>
+      </Panel>
+    </div>
+
     <ExampleModal
       v-model:visible="modalVisible"
       :initial-content="selectedExample.content"
@@ -40,18 +57,16 @@
 import { defineComponent, ref, onMounted, computed } from "vue";
 import { useExampleStore } from "@/stores/exampleStore";
 import { useUserStore } from "@/stores/userStore";
-import DataTable from "primevue/datatable";
-import Column from "primevue/column";
 import Button from "primevue/button";
+import Panel from "primevue/panel";
 import ExampleModal from "@/components/ExampleModal.vue";
 import type { PostExample } from "@/types";
 
 export default defineComponent({
   name: "ExamplesDashboard",
   components: {
-    DataTable,
-    Column,
     Button,
+    Panel,
     ExampleModal,
   },
   setup() {

--- a/src/pages/ExamplesDashboardPage.vue
+++ b/src/pages/ExamplesDashboardPage.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="container mx-auto px-4 py-8 min-h-screen flex flex-col max-w-3xl">
-    <h1 class="text-3xl font-bold mb-6">게시글 예시 관리</h1>
-
-    <div class="mb-8 flex justify-end">
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-3xl font-bold">게시글 예시 관리</h1>
       <Button
         label="새 예시 추가"
         icon="pi pi-plus"

--- a/src/pages/ExamplesDashboardPage.vue
+++ b/src/pages/ExamplesDashboardPage.vue
@@ -25,24 +25,18 @@
       >
         <template #icons>
           <Button
-            icon="pi pi-pencil"
+            icon="pi pi-cog"
             text
             rounded
-            aria-label="Edit"
-            @click.stop="editExample(example)"
-          />
-          <Button
-            icon="pi pi-trash"
-            severity="danger"
-            text
-            rounded
-            aria-label="Delete"
-            @click.stop="deleteExample(example.id)"
+            aria-label="Settings"
+            @click.stop="toggleMenu($event, example.id)"
           />
         </template>
         <p class="whitespace-pre-wrap text-sm">{{ example.content }}</p>
       </Panel>
     </div>
+
+    <Menu ref="menu" :model="menuItems" :popup="true" />
 
     <ExampleModal
       v-model:visible="modalVisible"
@@ -60,6 +54,7 @@ import { useUserStore } from "@/stores/userStore";
 import Button from "primevue/button";
 import Panel from "primevue/panel";
 import ExampleModal from "@/components/ExampleModal.vue";
+import Menu from "primevue/menu";
 import type { PostExample } from "@/types";
 
 export default defineComponent({
@@ -68,6 +63,7 @@ export default defineComponent({
     Button,
     Panel,
     ExampleModal,
+    Menu,
   },
   setup() {
     const exampleStore = useExampleStore();
@@ -123,6 +119,26 @@ export default defineComponent({
       await exampleStore.deleteExample(id);
     };
 
+    const menu = ref();
+    const menuItems = ref([
+      {
+        label: "수정",
+        icon: "pi pi-pencil",
+        command: () => editExample(selectedExample.value),
+      },
+      {
+        label: "삭제",
+        icon: "pi pi-trash",
+        command: () => deleteExample(selectedExample.value.id),
+      },
+    ]);
+
+    const toggleMenu = (event: Event, exampleId: string) => {
+      selectedExample.value =
+        examples.value.find((e) => e.id === exampleId) || selectedExample.value;
+      menu.value.toggle(event);
+    };
+
     return {
       examples,
       modalVisible,
@@ -132,6 +148,9 @@ export default defineComponent({
       editExample,
       saveExample,
       deleteExample,
+      menu,
+      menuItems,
+      toggleMenu,
     };
   },
 });

--- a/src/pages/ExamplesDashboardPage.vue
+++ b/src/pages/ExamplesDashboardPage.vue
@@ -36,6 +36,7 @@
     </div>
 
     <Menu ref="menu" :model="menuItems" :popup="true" />
+    <ConfirmPopup></ConfirmPopup>
 
     <ExampleModal
       v-model:visible="modalVisible"
@@ -54,6 +55,8 @@ import Button from "primevue/button";
 import Panel from "primevue/panel";
 import ExampleModal from "@/components/ExampleModal.vue";
 import Menu from "primevue/menu";
+import ConfirmPopup from "primevue/confirmpopup";
+import { useConfirm } from "primevue/useconfirm";
 import type { PostExample } from "@/types";
 
 export default defineComponent({
@@ -63,6 +66,7 @@ export default defineComponent({
     Panel,
     ExampleModal,
     Menu,
+    ConfirmPopup,
   },
   setup() {
     const exampleStore = useExampleStore();
@@ -76,6 +80,7 @@ export default defineComponent({
       updated_at: "",
     });
     const isEditing = ref(false);
+    const confirm = useConfirm();
 
     const examples = computed(() => exampleStore.examples);
 
@@ -128,7 +133,19 @@ export default defineComponent({
       {
         label: "삭제",
         icon: "pi pi-trash",
-        command: () => deleteExample(selectedExample.value.id),
+        command: (event: { originalEvent: { target: EventTarget } }) => {
+          confirm.require({
+            target: event.originalEvent.target as HTMLElement,
+            message: "이 예시를 삭제하시겠습니까?",
+            icon: "pi pi-exclamation-triangle",
+            accept: () => {
+              deleteExample(selectedExample.value.id);
+            },
+            reject: () => {
+              // 아무 작업도 하지 않음
+            },
+          });
+        },
       },
     ]);
 


### PR DESCRIPTION
💄 modify ExamplesDashboard layout

설정 토글화

헤더, 버튼 레이아웃 조정

confirmpopup 추가

- ExamplesDashboard 페이지의 레이아웃을 개선하여 사용성 향상
- DataTable을 Panel 컴포넌트로 대체하여 각 예시를 접을 수 있는 토글 형태로 변경
- 페이지 상단에 제목과 '새 예시 추가' 버튼을 배치하여 직관적인 인터페이스 구현
- 각 예시에 설정 메뉴를 추가하여 수정 및 삭제 기능에 쉽게 접근 가능
- 삭제 시 ConfirmPopup을 사용하여 사용자 확인 절차 추가
- 예시가 없을 때 안내 메시지 표시
- ConfirmationService를 main.ts에 추가하여 전역적으로 사용 가능하도록 설정