### PR TITLE
♻️ replace defineComponent to script setup

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,6 +2,7 @@ module.exports = {
   root: true,
   env: {
     node: true,
+    "vue/setup-compiler-macros": true,
   },
   extends: [
     "plugin:vue/vue3-essential",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,3 +1,8 @@
+<script setup lang="ts">
+import UserMenu from "@/components/UserMenu.vue";
+import "./assets/global.css";
+</script>
+
 <template>
   <div id="app" class="flex flex-col min-h-screen">
     <header class="bg-surface-0 shadow-md py-2 px-4">
@@ -16,16 +21,5 @@
     </main>
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent } from "vue";
-import UserMenu from "@/components/UserMenu.vue";
-import "./assets/global.css";
-
-export default defineComponent({
-  name: "App",
-  components: { UserMenu },
-});
-</script>
 
 <style></style>

--- a/src/components/AuthForm.vue
+++ b/src/components/AuthForm.vue
@@ -1,7 +1,43 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import Card from "primevue/card";
+import InputText from "primevue/inputtext";
+import Password from "primevue/password";
+import Button from "primevue/button";
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  submitLabel: {
+    type: String,
+    required: true,
+  },
+  footerLink: {
+    type: String,
+    required: true,
+  },
+  footerText: {
+    type: String,
+    required: true,
+  },
+});
+
+const emit = defineEmits(["submit"]);
+
+const email = ref("");
+const password = ref("");
+
+const handleSubmit = () => {
+  emit("submit", { email: email.value, password: password.value });
+};
+</script>
+
 <template>
   <div class="flex justify-center items-center h-screen bg-surface-100">
     <Card class="w-full max-w-md">
-      <template #title>{{ title }}</template>
+      <template #title>{{ props.title }}</template>
       <template #content>
         <form @submit.prevent="handleSubmit" class="space-y-4">
           <div>
@@ -27,55 +63,17 @@
               inputClass="w-full"
             />
           </div>
-          <Button type="submit" :label="submitLabel" class="w-full" />
+          <Button type="submit" :label="props.submitLabel" class="w-full" />
         </form>
       </template>
       <template #footer>
-        <router-link :to="footerLink" class="text-primary-600 hover:underline">
-          {{ footerText }}
+        <router-link
+          :to="props.footerLink"
+          class="text-primary-600 hover:underline"
+        >
+          {{ props.footerText }}
         </router-link>
       </template>
     </Card>
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent, ref } from "vue";
-import Card from "primevue/card";
-import InputText from "primevue/inputtext";
-import Password from "primevue/password";
-import Button from "primevue/button";
-
-export default defineComponent({
-  components: { Card, InputText, Password, Button },
-  props: {
-    title: {
-      type: String,
-      required: true,
-    },
-    submitLabel: {
-      type: String,
-      required: true,
-    },
-    footerLink: {
-      type: String,
-      required: true,
-    },
-    footerText: {
-      type: String,
-      required: true,
-    },
-  },
-  emits: ["submit"],
-  setup(props, { emit }) {
-    const email = ref("");
-    const password = ref("");
-
-    const handleSubmit = () => {
-      emit("submit", { email: email.value, password: password.value });
-    };
-
-    return { email, password, handleSubmit };
-  },
-});
-</script>

--- a/src/components/DirectTextInput.vue
+++ b/src/components/DirectTextInput.vue
@@ -1,3 +1,60 @@
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import Panel from "primevue/panel";
+import Textarea from "primevue/textarea";
+import Button from "primevue/button";
+
+const emit = defineEmits(["generate"]);
+
+const texts = ref([""]);
+
+const panelPt = {
+  root: {
+    class: "shadow-md rounded-lg overflow-hidden border border-surface-200",
+  },
+  header: { class: "bg-surface-50 p-4 border-b border-surface-200" },
+  content: { class: "bg-white" },
+  toggleableContent: { class: "transition-all duration-300 ease-in-out" },
+};
+
+const textareaPt = {
+  root: {
+    class:
+      "w-full p-3 border border-surface-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all duration-200",
+  },
+};
+
+const buttonPt = {
+  root: {
+    class:
+      "bg-primary-600 hover:bg-primary-700 text-primary-50 font-bold px-6 py-3 rounded-md transition-colors duration-200 shadow-md hover:shadow-lg",
+  },
+};
+
+const addText = () => {
+  if (texts.value.length < 5) {
+    texts.value.push("");
+  }
+};
+
+const removeText = (index: number) => {
+  texts.value.splice(index, 1);
+};
+
+const isValid = computed(() => texts.value.some((text) => text.trim() !== ""));
+
+const generatePost = () => {
+  if (isValid.value) {
+    emit(
+      "generate",
+      texts.value.filter((text) => text.trim() !== "")
+    );
+  }
+};
+
+const primaryButtonPt = buttonPt;
+</script>
+
 <template>
   <div class="w-full max-w-xl">
     <div v-for="(text, index) in texts" :key="index" class="mb-6">
@@ -56,75 +113,3 @@
     </div>
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent, ref, computed } from "vue";
-import Panel from "primevue/panel";
-import Textarea from "primevue/textarea";
-import Button from "primevue/button";
-
-export default defineComponent({
-  components: { Panel, Textarea, Button },
-  emits: ["generate"],
-  setup(props, { emit }) {
-    const texts = ref([""]);
-
-    const panelPt = {
-      root: {
-        class: "shadow-md rounded-lg overflow-hidden border border-surface-200",
-      },
-      header: { class: "bg-surface-50 p-4 border-b border-surface-200" },
-      content: { class: "bg-white" },
-      toggleableContent: { class: "transition-all duration-300 ease-in-out" },
-    };
-
-    const textareaPt = {
-      root: {
-        class:
-          "w-full p-3 border border-surface-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all duration-200",
-      },
-    };
-
-    const buttonPt = {
-      root: {
-        class:
-          "bg-primary-600 hover:bg-primary-700 text-primary-50 font-bold px-6 py-3 rounded-md transition-colors duration-200 shadow-md hover:shadow-lg",
-      },
-    };
-
-    const addText = () => {
-      if (texts.value.length < 5) {
-        texts.value.push("");
-      }
-    };
-
-    const removeText = (index: number) => {
-      texts.value.splice(index, 1);
-    };
-
-    const isValid = computed(() =>
-      texts.value.some((text) => text.trim() !== "")
-    );
-
-    const generatePost = () => {
-      if (isValid.value) {
-        emit(
-          "generate",
-          texts.value.filter((text) => text.trim() !== "")
-        );
-      }
-    };
-
-    return {
-      texts,
-      panelPt,
-      textareaPt,
-      primaryButtonPt: buttonPt,
-      addText,
-      removeText,
-      isValid,
-      generatePost,
-    };
-  },
-});
-</script>

--- a/src/components/ExampleModal.vue
+++ b/src/components/ExampleModal.vue
@@ -1,10 +1,54 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import Dialog from "primevue/dialog";
+import Button from "primevue/button";
+import Textarea from "primevue/textarea";
+
+const props = defineProps({
+  visible: {
+    type: Boolean,
+    required: true,
+  },
+  initialContent: {
+    type: String,
+    default: "",
+  },
+  isEditing: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(["update:visible", "save"]);
+
+const content = ref(props.initialContent);
+
+watch(
+  () => props.visible,
+  (newVisible) => {
+    if (newVisible) {
+      content.value = props.initialContent;
+    }
+  }
+);
+
+const close = () => {
+  emit("update:visible", false);
+};
+
+const save = () => {
+  emit("save", content.value);
+  close();
+};
+</script>
+
 <template>
   <Dialog
-    :visible="visible"
+    :visible="props.visible"
     :style="{ width: '90%', maxWidth: '600px' }"
     :modal="true"
     :closable="false"
-    :header="isEditing ? '게시글 예시 수정' : '게시글 예시 등록'"
+    :header="props.isEditing ? '게시글 예시 수정' : '게시글 예시 등록'"
   >
     <div class="p-fluid p-4">
       <div class="field">
@@ -31,61 +75,3 @@
     </template>
   </Dialog>
 </template>
-
-<script lang="ts">
-import { defineComponent, ref, watch } from "vue";
-import Dialog from "primevue/dialog";
-import Button from "primevue/button";
-import Textarea from "primevue/textarea";
-
-export default defineComponent({
-  name: "ExampleModal",
-  components: {
-    Dialog,
-    Button,
-    Textarea,
-  },
-  props: {
-    visible: {
-      type: Boolean,
-      required: true,
-    },
-    initialContent: {
-      type: String,
-      default: "",
-    },
-    isEditing: {
-      type: Boolean,
-      default: false,
-    },
-  },
-  emits: ["update:visible", "save"],
-  setup(props, { emit }) {
-    const content = ref(props.initialContent);
-
-    watch(
-      () => props.visible,
-      (newVisible) => {
-        if (newVisible) {
-          content.value = props.initialContent;
-        }
-      }
-    );
-
-    const close = () => {
-      emit("update:visible", false);
-    };
-
-    const save = () => {
-      emit("save", content.value);
-      close();
-    };
-
-    return {
-      content,
-      close,
-      save,
-    };
-  },
-});
-</script>

--- a/src/components/GeneratedPost.vue
+++ b/src/components/GeneratedPost.vue
@@ -1,3 +1,15 @@
+<script setup lang="ts">
+import Card from "primevue/card";
+import Avatar from "primevue/avatar";
+
+const props = defineProps({
+  content: {
+    type: String,
+    required: true,
+  },
+});
+</script>
+
 <template>
   <Card
     :pt="{
@@ -38,7 +50,7 @@
         <p class="font-semibold text-sm pb-1">1,235 likes</p>
         <p class="text-sm leading-5">
           <span class="font-semibold mr-1">username</span>
-          {{ content }}
+          {{ props.content }}
         </p>
         <p
           class="text-sm text-surface-500 dark:text-surface-400 pt-1 cursor-pointer"
@@ -50,23 +62,3 @@
     </template>
   </Card>
 </template>
-
-<script lang="ts">
-import { defineComponent, PropType } from "vue";
-import Card from "primevue/card";
-import Avatar from "primevue/avatar";
-
-export default defineComponent({
-  name: "GeneratedPost",
-  components: {
-    Card,
-    Avatar,
-  },
-  props: {
-    content: {
-      type: String as PropType<string>,
-      required: true,
-    },
-  },
-});
-</script>

--- a/src/components/KeywordInput.vue
+++ b/src/components/KeywordInput.vue
@@ -1,10 +1,33 @@
+<script setup lang="ts">
+import InputText from "primevue/inputtext";
+import IconField from "primevue/iconfield";
+import InputIcon from "primevue/inputicon";
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    required: true,
+  },
+  placeholder: {
+    type: String,
+    default: "키워드를 입력해주세요...",
+  },
+});
+
+const emit = defineEmits(["update:modelValue", "generate"]);
+
+const updateModelValue = (event: Event) => {
+  emit("update:modelValue", (event.target as HTMLInputElement).value);
+};
+</script>
+
 <template>
   <div class="w-full max-w-xl mb-6">
     <IconField class="w-full" :pt="{ root: 'relative w-full' }">
       <InputText
-        :value="modelValue"
-        @input="$emit('update:modelValue', $event.target.value)"
-        :placeholder="placeholder"
+        :value="props.modelValue"
+        @input="updateModelValue"
+        :placeholder="props.placeholder"
         class="w-full flex-1 rounded-full h-14 pl-6 pr-14 text-lg border-2 border-primary-300 focus:border-primary-500 focus:ring-2 focus:ring-primary-500/50 dark:focus:ring-primary-400/50"
         @keyup.enter="$emit('generate')"
       />
@@ -17,29 +40,3 @@
     </IconField>
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent } from "vue";
-import InputText from "primevue/inputtext";
-import IconField from "primevue/iconfield";
-import InputIcon from "primevue/inputicon";
-
-export default defineComponent({
-  components: {
-    InputText,
-    IconField,
-    InputIcon,
-  },
-  props: {
-    modelValue: {
-      type: String,
-      required: true,
-    },
-    placeholder: {
-      type: String,
-      default: "키워드를 입력해주세요...",
-    },
-  },
-  emits: ["update:modelValue", "generate"],
-});
-</script>

--- a/src/components/LinkPreview.vue
+++ b/src/components/LinkPreview.vue
@@ -1,13 +1,44 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import Button from "primevue/button";
+import type { NewsItem } from "../types";
+
+const props = defineProps<{
+  newsItem: NewsItem;
+  selected: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "toggle-selection", item: NewsItem): void;
+}>();
+
+const cleanText = (text: string) => {
+  return text
+    .replace(/<\/?b>/g, "")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .trim();
+};
+
+const cleanTitle = computed(() => cleanText(props.newsItem.title));
+const cleanDescription = computed(() => cleanText(props.newsItem.description));
+</script>
+
 <template>
   <div
     class="border rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-shadow duration-300 p-4"
-    :class="{ 'border-primary-500': selected, 'border-gray-200': !selected }"
+    :class="{
+      'border-primary-500': props.selected,
+      'border-gray-200': !props.selected,
+    }"
   >
     <h3 class="font-bold text-lg mb-2">{{ cleanTitle }}</h3>
     <p class="text-gray-600 text-sm mb-4">{{ cleanDescription }}</p>
     <div class="flex justify-between items-center">
       <a
-        :href="newsItem.link"
+        :href="props.newsItem.link"
         target="_blank"
         rel="noopener noreferrer"
         class="text-primary-600 hover:text-primary-800 transition-colors duration-300"
@@ -15,53 +46,10 @@
         자세히 보기
       </a>
       <Button
-        :icon="selected ? 'pi pi-check-square' : 'pi pi-square'"
-        :class="{ 'p-button-outlined': !selected }"
-        @click="$emit('toggle-selection', newsItem)"
+        :icon="props.selected ? 'pi pi-check-square' : 'pi pi-square'"
+        :class="{ 'p-button-outlined': !props.selected }"
+        @click="emit('toggle-selection', props.newsItem)"
       />
     </div>
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent, PropType, computed } from "vue";
-import Button from "primevue/button";
-import type { NewsItem } from "../types";
-
-export default defineComponent({
-  name: "LinkPreview",
-  components: { Button },
-  props: {
-    newsItem: {
-      type: Object as PropType<NewsItem>,
-      required: true,
-    },
-    selected: {
-      type: Boolean,
-      default: false,
-    },
-  },
-  emits: ["toggle-selection"],
-  setup(props) {
-    const cleanText = (text: string) => {
-      return text
-        .replace(/<\/?b>/g, "")
-        .replace(/&quot;/g, '"')
-        .replace(/&amp;/g, "&")
-        .replace(/&lt;/g, "<")
-        .replace(/&gt;/g, ">")
-        .trim();
-    };
-
-    const cleanTitle = computed(() => cleanText(props.newsItem.title));
-    const cleanDescription = computed(() =>
-      cleanText(props.newsItem.description)
-    );
-
-    return {
-      cleanTitle,
-      cleanDescription,
-    };
-  },
-});
-</script>

--- a/src/components/LoadingComponent.vue
+++ b/src/components/LoadingComponent.vue
@@ -1,3 +1,46 @@
+<script setup lang="ts">
+import { ref, watch, onMounted } from "vue";
+import ProgressSpinner from "primevue/progressspinner";
+import type { LoadingStage } from "@/types";
+
+const props = defineProps<{
+  stage: LoadingStage;
+  progress: number;
+}>();
+
+const loadingMessage = ref("");
+const displayedMessage = ref("");
+
+const updateLoadingState = (stage: LoadingStage) => {
+  switch (stage) {
+    case "references":
+      loadingMessage.value = "참조 자료를 수집하는 중...";
+      break;
+    case "generating":
+      loadingMessage.value = "포스트를 생성하는 중...";
+      break;
+    case "finalizing":
+      loadingMessage.value = "최종 결과를 준비하는 중...";
+      break;
+    default:
+      loadingMessage.value = "준비 중...";
+  }
+  displayedMessage.value = loadingMessage.value;
+};
+
+// 초기 로딩 메시지 설정
+onMounted(() => {
+  updateLoadingState(props.stage);
+});
+
+watch(
+  () => props.stage,
+  (newStage) => {
+    updateLoadingState(newStage);
+  }
+);
+</script>
+
 <template>
   <div
     class="flex flex-col items-center justify-center h-screen text-center bg-primary-50"
@@ -10,7 +53,9 @@
         animationDuration=".5s"
       />
       <div class="absolute inset-0 flex items-center justify-center">
-        <span class="text-2xl font-bold text-primary-500">{{ progress }}%</span>
+        <span class="text-2xl font-bold text-primary-500"
+          >{{ props.progress }}%</span
+        >
       </div>
     </div>
     <p class="mt-6 text-xl font-semibold text-primary-800">
@@ -18,61 +63,3 @@
     </p>
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent, ref, watch, onMounted } from "vue";
-import ProgressSpinner from "primevue/progressspinner";
-import type { LoadingStage } from "@/types";
-
-export default defineComponent({
-  name: "LoadingComponent",
-  components: { ProgressSpinner },
-  props: {
-    stage: {
-      type: String as () => LoadingStage,
-      required: true,
-    },
-    progress: {
-      type: Number,
-      required: true,
-    },
-  },
-  setup(props) {
-    const loadingMessage = ref("");
-    const displayedMessage = ref("");
-
-    const updateLoadingState = (stage: LoadingStage) => {
-      switch (stage) {
-        case "references":
-          loadingMessage.value = "참조 자료를 수집하는 중...";
-          break;
-        case "generating":
-          loadingMessage.value = "포스트를 생성하는 중...";
-          break;
-        case "finalizing":
-          loadingMessage.value = "최종 결과를 준비하는 중...";
-          break;
-        default:
-          loadingMessage.value = "준비 중...";
-      }
-      displayedMessage.value = loadingMessage.value;
-    };
-
-    // 초기 로딩 메시지 설정
-    onMounted(() => {
-      updateLoadingState(props.stage);
-    });
-
-    watch(
-      () => props.stage,
-      (newStage) => {
-        updateLoadingState(newStage);
-      }
-    );
-
-    return {
-      displayedMessage,
-    };
-  },
-});
-</script>

--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -1,3 +1,43 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
+import { useUserStore } from "@/stores/userStore";
+import Menu from "primevue/menu";
+import Button from "primevue/button";
+
+const router = useRouter();
+const userStore = useUserStore();
+const menu = ref();
+
+const isLoggedIn = computed(() => userStore.isLoggedIn);
+
+const items = [
+  {
+    label: "예시 관리",
+    icon: "pi pi-list",
+    command: () => {
+      router.push("/examples");
+    },
+  },
+  {
+    label: "로그아웃",
+    icon: "pi pi-sign-out",
+    command: async () => {
+      await userStore.logout();
+      router.push("/signin");
+    },
+  },
+];
+
+const navigateToSignIn = () => {
+  router.push("/signin");
+};
+
+const toggle = (event: Event) => {
+  menu.value.toggle(event);
+};
+</script>
+
 <template>
   <div>
     <template v-if="isLoggedIn">
@@ -21,50 +61,3 @@
     />
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent, computed, ref } from "vue";
-import { useRouter } from "vue-router";
-import { useUserStore } from "@/stores/userStore";
-import Menu from "primevue/menu";
-import Button from "primevue/button";
-
-export default defineComponent({
-  components: { Menu, Button },
-  setup() {
-    const router = useRouter();
-    const userStore = useUserStore();
-    const menu = ref();
-
-    const isLoggedIn = computed(() => userStore.isLoggedIn);
-
-    const items = [
-      {
-        label: "예시 관리",
-        icon: "pi pi-list",
-        command: () => {
-          router.push("/examples");
-        },
-      },
-      {
-        label: "로그아웃",
-        icon: "pi pi-sign-out",
-        command: async () => {
-          await userStore.logout();
-          router.push("/signin");
-        },
-      },
-    ];
-
-    const navigateToSignIn = () => {
-      router.push("/signin");
-    };
-
-    const toggle = (event: Event) => {
-      menu.value.toggle(event);
-    };
-
-    return { isLoggedIn, items, navigateToSignIn, menu, toggle };
-  },
-});
-</script>

--- a/src/pages/ExamplesDashboardPage.vue
+++ b/src/pages/ExamplesDashboardPage.vue
@@ -1,3 +1,102 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from "vue";
+import { useExampleStore } from "@/stores/exampleStore";
+import { useUserStore } from "@/stores/userStore";
+import Button from "primevue/button";
+import Panel from "primevue/panel";
+import ExampleModal from "@/components/ExampleModal.vue";
+import Menu from "primevue/menu";
+import ConfirmPopup from "primevue/confirmpopup";
+import { useConfirm } from "primevue/useconfirm";
+import type { PostExample } from "@/types";
+
+const exampleStore = useExampleStore();
+const userStore = useUserStore();
+const modalVisible = ref(false);
+const selectedExample = ref<PostExample>({
+  id: "",
+  user_id: "",
+  content: "",
+  created_at: "",
+  updated_at: "",
+});
+const isEditing = ref(false);
+const confirm = useConfirm();
+
+const examples = computed(() => exampleStore.examples);
+
+onMounted(async () => {
+  if (userStore.user) {
+    await exampleStore.fetchExamples(userStore.user.id);
+  }
+});
+
+const openAddModal = () => {
+  selectedExample.value = {
+    id: "",
+    user_id: "",
+    content: "",
+    created_at: "",
+    updated_at: "",
+  };
+  isEditing.value = false;
+  modalVisible.value = true;
+};
+
+const editExample = (example: PostExample) => {
+  selectedExample.value = { ...example };
+  isEditing.value = true;
+  modalVisible.value = true;
+};
+
+const saveExample = async (content: string) => {
+  if (userStore.user) {
+    if (isEditing.value) {
+      await exampleStore.updateExample(selectedExample.value.id, content);
+    } else {
+      await exampleStore.addExample(userStore.user.id, content);
+    }
+    modalVisible.value = false;
+  }
+};
+
+const deleteExample = async (id: string) => {
+  await exampleStore.deleteExample(id);
+};
+
+const menu = ref();
+const menuItems = ref([
+  {
+    label: "수정",
+    icon: "pi pi-pencil",
+    command: () => editExample(selectedExample.value),
+  },
+  {
+    label: "삭제",
+    icon: "pi pi-trash",
+    command: (event: { originalEvent: { target: EventTarget } }) => {
+      confirm.require({
+        target: event.originalEvent.target as HTMLElement,
+        message: "이 예시를 삭제하시겠습니까?",
+        icon: "pi pi-exclamation-triangle",
+        accept: () => {
+          deleteExample(selectedExample.value.id);
+        },
+        reject: () => {
+          // 아무 작업도 하지 않음
+        },
+      });
+    },
+  },
+]);
+
+const toggleMenu = (event: Event, exampleId: string) => {
+  selectedExample.value =
+    examples.value.find((e) => e.id === exampleId) || selectedExample.value;
+  menu.value.toggle(event);
+};
+</script>
+
 <template>
   <div class="container mx-auto px-4 py-8 min-h-screen flex flex-col max-w-3xl">
     <div class="flex justify-between items-center mb-6">
@@ -46,128 +145,3 @@
     />
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent, ref, onMounted, computed } from "vue";
-import { useExampleStore } from "@/stores/exampleStore";
-import { useUserStore } from "@/stores/userStore";
-import Button from "primevue/button";
-import Panel from "primevue/panel";
-import ExampleModal from "@/components/ExampleModal.vue";
-import Menu from "primevue/menu";
-import ConfirmPopup from "primevue/confirmpopup";
-import { useConfirm } from "primevue/useconfirm";
-import type { PostExample } from "@/types";
-
-export default defineComponent({
-  name: "ExamplesDashboard",
-  components: {
-    Button,
-    Panel,
-    ExampleModal,
-    Menu,
-    ConfirmPopup,
-  },
-  setup() {
-    const exampleStore = useExampleStore();
-    const userStore = useUserStore();
-    const modalVisible = ref(false);
-    const selectedExample = ref<PostExample>({
-      id: "",
-      user_id: "",
-      content: "",
-      created_at: "",
-      updated_at: "",
-    });
-    const isEditing = ref(false);
-    const confirm = useConfirm();
-
-    const examples = computed(() => exampleStore.examples);
-
-    onMounted(async () => {
-      if (userStore.user) {
-        await exampleStore.fetchExamples(userStore.user.id);
-      }
-    });
-
-    const openAddModal = () => {
-      selectedExample.value = {
-        id: "",
-        user_id: "",
-        content: "",
-        created_at: "",
-        updated_at: "",
-      };
-      isEditing.value = false;
-      modalVisible.value = true;
-    };
-
-    const editExample = (example: PostExample) => {
-      selectedExample.value = { ...example };
-      isEditing.value = true;
-      modalVisible.value = true;
-    };
-
-    const saveExample = async (content: string) => {
-      if (userStore.user) {
-        if (isEditing.value) {
-          await exampleStore.updateExample(selectedExample.value.id, content);
-        } else {
-          await exampleStore.addExample(userStore.user.id, content);
-        }
-        modalVisible.value = false;
-      }
-    };
-
-    const deleteExample = async (id: string) => {
-      await exampleStore.deleteExample(id);
-    };
-
-    const menu = ref();
-    const menuItems = ref([
-      {
-        label: "수정",
-        icon: "pi pi-pencil",
-        command: () => editExample(selectedExample.value),
-      },
-      {
-        label: "삭제",
-        icon: "pi pi-trash",
-        command: (event: { originalEvent: { target: EventTarget } }) => {
-          confirm.require({
-            target: event.originalEvent.target as HTMLElement,
-            message: "이 예시를 삭제하시겠습니까?",
-            icon: "pi pi-exclamation-triangle",
-            accept: () => {
-              deleteExample(selectedExample.value.id);
-            },
-            reject: () => {
-              // 아무 작업도 하지 않음
-            },
-          });
-        },
-      },
-    ]);
-
-    const toggleMenu = (event: Event, exampleId: string) => {
-      selectedExample.value =
-        examples.value.find((e) => e.id === exampleId) || selectedExample.value;
-      menu.value.toggle(event);
-    };
-
-    return {
-      examples,
-      modalVisible,
-      selectedExample,
-      isEditing,
-      openAddModal,
-      editExample,
-      saveExample,
-      deleteExample,
-      menu,
-      menuItems,
-      toggleMenu,
-    };
-  },
-});
-</script>

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -1,3 +1,36 @@
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { useRouter } from "vue-router";
+import { useArticleStore } from "../stores/articleStore";
+import { useInputMode } from "../composables/useInputMode";
+import SelectButton from "primevue/selectbutton";
+import DirectTextInput from "../components/DirectTextInput.vue";
+import KeywordInput from "../components/KeywordInput.vue";
+
+const topic = ref("");
+const router = useRouter();
+const articleStore = useArticleStore();
+const { inputModes, inputMode } = useInputMode();
+
+const searchNews = async () => {
+  if (topic.value.trim()) {
+    await articleStore.setTopic(topic.value.trim());
+    router.push("/news-selection");
+  }
+};
+
+const generatePostFromText = async (texts: string[]) => {
+  await articleStore.setDirectTexts(texts);
+  router.push("/result");
+};
+
+const inputModeDescription = computed(() =>
+  inputMode.value === "keyword"
+    ? "관련 뉴스를 찾아 포스트를 생성해드려요 ☺️"
+    : "입력한 텍스트를 기반으로 포스트를 생성해드려요 ☺️"
+);
+</script>
+
 <template>
   <div
     class="flex flex-col items-center justify-center min-h-[calc(100vh-4rem)] px-4 bg-surface-50"
@@ -36,54 +69,3 @@
     </div>
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent, ref, computed } from "vue";
-import { useRouter } from "vue-router";
-import { useArticleStore } from "../stores/articleStore";
-import { useInputMode } from "../composables/useInputMode";
-import SelectButton from "primevue/selectbutton";
-import DirectTextInput from "../components/DirectTextInput.vue";
-import KeywordInput from "../components/KeywordInput.vue";
-
-export default defineComponent({
-  components: {
-    SelectButton,
-    DirectTextInput,
-    KeywordInput,
-  },
-  setup() {
-    const topic = ref("");
-    const router = useRouter();
-    const articleStore = useArticleStore();
-    const { inputModes, inputMode } = useInputMode();
-
-    const searchNews = async () => {
-      if (topic.value.trim()) {
-        await articleStore.setTopic(topic.value.trim());
-        router.push("/news-selection");
-      }
-    };
-
-    const generatePostFromText = async (texts: string[]) => {
-      await articleStore.setDirectTexts(texts);
-      router.push("/result");
-    };
-
-    const inputModeDescription = computed(() =>
-      inputMode.value === "keyword"
-        ? "관련 뉴스를 찾아 포스트를 생성해드려요 ☺️"
-        : "입력한 텍스트를 기반으로 포스트를 생성해드려요 ☺️"
-    );
-
-    return {
-      topic,
-      searchNews,
-      inputModes,
-      inputMode,
-      generatePostFromText,
-      inputModeDescription,
-    };
-  },
-});
-</script>

--- a/src/pages/ResultPage.vue
+++ b/src/pages/ResultPage.vue
@@ -1,3 +1,34 @@
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { useRouter } from "vue-router";
+import GeneratedPost from "../components/GeneratedPost.vue";
+import LoadingComponent from "../components/LoadingComponent.vue";
+import Button from "primevue/button";
+import Message from "primevue/message";
+import Toast from "primevue/toast";
+import { usePostGeneration } from "../composables/usePostGeneration";
+
+const router = useRouter();
+const {
+  isLoading,
+  loadingStage,
+  error,
+  generatedPost,
+  copyPost,
+  generatePost,
+  regeneratePost,
+  progressPercentage,
+} = usePostGeneration();
+
+onMounted(async () => {
+  await generatePost();
+});
+
+const goToHome = () => {
+  router.push("/");
+};
+</script>
+
 <template>
   <div class="result-page">
     <Toast />
@@ -30,57 +61,3 @@
     <Toast position="bottom-center" group="bc" />
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent, onMounted } from "vue";
-import { useRouter } from "vue-router";
-import GeneratedPost from "../components/GeneratedPost.vue";
-import LoadingComponent from "../components/LoadingComponent.vue";
-import Button from "primevue/button";
-import Message from "primevue/message";
-import Toast from "primevue/toast";
-import { usePostGeneration } from "../composables/usePostGeneration";
-
-export default defineComponent({
-  name: "ResultPage",
-  components: {
-    GeneratedPost,
-    LoadingComponent,
-    Button,
-    Message,
-    Toast,
-  },
-  setup() {
-    const router = useRouter();
-    const {
-      isLoading,
-      loadingStage,
-      error,
-      generatedPost,
-      copyPost,
-      generatePost,
-      regeneratePost,
-      progressPercentage,
-    } = usePostGeneration();
-
-    onMounted(async () => {
-      await generatePost();
-    });
-
-    const goToHome = () => {
-      router.push("/");
-    };
-
-    return {
-      isLoading,
-      loadingStage,
-      error,
-      generatedPost,
-      copyPost,
-      regeneratePost,
-      progressPercentage,
-      goToHome,
-    };
-  },
-});
-</script>

--- a/src/pages/SignInPage.vue
+++ b/src/pages/SignInPage.vue
@@ -1,3 +1,31 @@
+<script setup lang="ts">
+import { useRouter } from "vue-router";
+import { useUserStore } from "../stores/userStore";
+import { useToast } from "../composables/useToast";
+import AuthForm from "@/components/AuthForm.vue";
+import Toast from "primevue/toast";
+
+const router = useRouter();
+const userStore = useUserStore();
+const { showError } = useToast();
+
+const handleSignIn = async ({
+  email,
+  password,
+}: {
+  email: string;
+  password: string;
+}) => {
+  try {
+    await userStore.login(email, password);
+    router.push("/");
+  } catch (error) {
+    console.error("Sign in failed:", error);
+    showError("로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.");
+  }
+};
+</script>
+
 <template>
   <div>
     <AuthForm
@@ -10,39 +38,3 @@
     <Toast position="top-right" />
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent } from "vue";
-import { useRouter } from "vue-router";
-import { useUserStore } from "../stores/userStore";
-import { useToast } from "../composables/useToast";
-import AuthForm from "@/components/AuthForm.vue";
-import Toast from "primevue/toast";
-
-export default defineComponent({
-  components: { AuthForm, Toast },
-  setup() {
-    const router = useRouter();
-    const userStore = useUserStore();
-    const { showError } = useToast();
-
-    const handleSignIn = async ({
-      email,
-      password,
-    }: {
-      email: string;
-      password: string;
-    }) => {
-      try {
-        await userStore.login(email, password);
-        router.push("/");
-      } catch (error) {
-        console.error("Sign in failed:", error);
-        showError("로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.");
-      }
-    };
-
-    return { handleSignIn };
-  },
-});
-</script>

--- a/src/pages/SignUpPage.vue
+++ b/src/pages/SignUpPage.vue
@@ -1,3 +1,33 @@
+<script setup lang="ts">
+import { useRouter } from "vue-router";
+import { useUserStore } from "../stores/userStore";
+import { useToast } from "../composables/useToast";
+import AuthForm from "@/components/AuthForm.vue";
+import Toast from "primevue/toast";
+
+const router = useRouter();
+const userStore = useUserStore();
+const { showError } = useToast();
+
+const handleSignUp = async ({
+  email,
+  password,
+}: {
+  email: string;
+  password: string;
+}) => {
+  try {
+    await userStore.register(email, password);
+    router.push("/");
+  } catch (error) {
+    console.error("Sign up failed:", error);
+    showError(
+      "회원가입에 실패했습니다. 문제가 계속되면 관리자에게 문의해주세요."
+    );
+  }
+};
+</script>
+
 <template>
   <div>
     <AuthForm
@@ -10,41 +40,3 @@
     <Toast position="top-right" />
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent } from "vue";
-import { useRouter } from "vue-router";
-import { useUserStore } from "../stores/userStore";
-import { useToast } from "../composables/useToast";
-import AuthForm from "@/components/AuthForm.vue";
-import Toast from "primevue/toast";
-
-export default defineComponent({
-  components: { AuthForm, Toast },
-  setup() {
-    const router = useRouter();
-    const userStore = useUserStore();
-    const { showError } = useToast();
-
-    const handleSignUp = async ({
-      email,
-      password,
-    }: {
-      email: string;
-      password: string;
-    }) => {
-      try {
-        await userStore.register(email, password);
-        router.push("/");
-      } catch (error) {
-        console.error("Sign up failed:", error);
-        showError(
-          "회원가입에 실패했습니다. 문제가 계속되면 관리자에게 문의해주세요."
-        );
-      }
-    };
-
-    return { handleSignUp };
-  },
-});
-</script>


### PR DESCRIPTION
### TL;DR

Refactored Vue components to use the Composition API and `<script setup>` syntax.

### What changed?

- Updated `.eslintrc.cjs` to enable Vue 3 compiler macros
- Refactored all Vue components to use `<script setup>` syntax
- Moved component logic from `export default defineComponent(...)` to the `<script setup>` section
- Replaced `this` references with direct variable usage
- Removed unnecessary imports and component registrations
- Simplified prop and emit declarations

### How to test?

1. Run the application and verify that all pages and components function as expected
2. Test user interactions on each page (e.g., sign in, sign up, news selection, post generation)
3. Verify that all existing functionality remains intact
4. Check for any console errors or warnings related to the refactoring

### Why make this change?

This refactoring improves code readability, reduces boilerplate, and leverages Vue 3's Composition API features. The `<script setup>` syntax provides a more concise way to define component logic, making the code easier to maintain and understand. It also allows for better TypeScript integration and improved performance through compile-time optimizations.