### PR TITLE
♻️ rename object

### DIFF
--- a/src/composables/usePostGeneration.ts
+++ b/src/composables/usePostGeneration.ts
@@ -1,6 +1,6 @@
 import { ref } from "vue";
 import { useArticleStore } from "../stores/articleStore";
-import { useExampleStore } from "../stores/exampleStore";
+import { usePostExampleStore } from "../stores/postExampleStore";
 import { usePostGuidelineStore } from "../stores/postGuidelineStore";
 import { useUserStore } from "../stores/userStore";
 import { useToast } from "primevue/usetoast";
@@ -9,7 +9,7 @@ import type { Reference, PostExample, PostGuideline } from "../types";
 
 export function usePostGeneration() {
   const articleStore = useArticleStore();
-  const exampleStore = useExampleStore();
+  const postExampleStore = usePostExampleStore();
   const postGuidelineStore = usePostGuidelineStore();
   const userStore = useUserStore();
   const toast = useToast();
@@ -52,7 +52,9 @@ export function usePostGeneration() {
       }
 
       if (userStore.isLoggedIn && userStore.user) {
-        examples.value = await exampleStore.fetchExamples(userStore.user.id);
+        examples.value = await postExampleStore.fetchExamples(
+          userStore.user.id
+        );
         guideline.value = await postGuidelineStore.getGuideline(
           userStore.user.id
         );

--- a/src/pages/ExamplesDashboardPage.vue
+++ b/src/pages/ExamplesDashboardPage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from "vue";
-import { useExampleStore } from "@/stores/exampleStore";
+import { usePostExampleStore } from "@/stores/postExampleStore";
 import { useUserStore } from "@/stores/userStore";
 import Button from "primevue/button";
 import Panel from "primevue/panel";
@@ -10,7 +10,7 @@ import ConfirmPopup from "primevue/confirmpopup";
 import { useConfirm } from "primevue/useconfirm";
 import type { PostExample } from "@/types";
 
-const exampleStore = useExampleStore();
+const postExampleStore = usePostExampleStore();
 const userStore = useUserStore();
 const modalVisible = ref(false);
 const selectedExample = ref<PostExample>({
@@ -23,11 +23,11 @@ const selectedExample = ref<PostExample>({
 const isEditing = ref(false);
 const confirm = useConfirm();
 
-const examples = computed(() => exampleStore.examples);
+const examples = computed(() => postExampleStore.examples);
 
 onMounted(async () => {
   if (userStore.user) {
-    await exampleStore.fetchExamples(userStore.user.id);
+    await postExampleStore.fetchExamples(userStore.user.id);
   }
 });
 
@@ -52,16 +52,16 @@ const editExample = (example: PostExample) => {
 const saveExample = async (content: string) => {
   if (userStore.user) {
     if (isEditing.value) {
-      await exampleStore.updateExample(selectedExample.value.id, content);
+      await postExampleStore.updateExample(selectedExample.value.id, content);
     } else {
-      await exampleStore.addExample(userStore.user.id, content);
+      await postExampleStore.addExample(userStore.user.id, content);
     }
     modalVisible.value = false;
   }
 };
 
 const deleteExample = async (id: string) => {
-  await exampleStore.deleteExample(id);
+  await postExampleStore.deleteExample(id);
 };
 
 const menu = ref();

--- a/src/services/PostExampleService.ts
+++ b/src/services/PostExampleService.ts
@@ -1,8 +1,8 @@
 import { supabase } from "@/supabase";
 import type { PostExample } from "@/types";
 
-export class ExampleService {
-  async getExamples(userId: string): Promise<PostExample[]> {
+export class PostExampleService {
+  async fetchExamples(userId: string): Promise<PostExample[]> {
     const { data, error } = await supabase
       .from("post_examples")
       .select("*")

--- a/src/stores/postExampleStore.ts
+++ b/src/stores/postExampleStore.ts
@@ -1,31 +1,34 @@
 import { defineStore } from "pinia";
-import { ExampleService } from "@/services/ExampleService";
+import { PostExampleService } from "@/services/PostExampleService";
 import type { PostExample } from "@/types";
 
-const exampleService = new ExampleService();
+const postExampleService = new PostExampleService();
 
-export const useExampleStore = defineStore("example", {
+export const usePostExampleStore = defineStore("example", {
   state: () => ({
     examples: [] as PostExample[],
   }),
   actions: {
     async fetchExamples(userId: string): Promise<PostExample[]> {
-      this.examples = await exampleService.getExamples(userId);
+      this.examples = await postExampleService.fetchExamples(userId);
       return this.examples;
     },
     async addExample(userId: string, content: string) {
-      const newExample = await exampleService.addExample(userId, content);
+      const newExample = await postExampleService.addExample(userId, content);
       this.examples.push(newExample);
     },
     async updateExample(id: string, content: string) {
-      const updatedExample = await exampleService.updateExample(id, content);
+      const updatedExample = await postExampleService.updateExample(
+        id,
+        content
+      );
       const index = this.examples.findIndex((e) => e.id === id);
       if (index !== -1) {
         this.examples[index] = updatedExample;
       }
     },
     async deleteExample(id: string) {
-      await exampleService.deleteExample(id);
+      await postExampleService.deleteExample(id);
       this.examples = this.examples.filter((e) => e.id !== id);
     },
   },


### PR DESCRIPTION
### TL;DR
Renamed Example-related files and components to PostExample to better reflect their purpose in handling post examples.

### What changed?
- Renamed `ExampleService` to `PostExampleService`
- Renamed `exampleStore` to `postExampleStore`
- Updated all related imports and references across components
- Renamed `getExamples` method to `fetchExamples` in the service class for consistency

### How to test?
1. Navigate to the Examples Dashboard page
2. Verify that all CRUD operations for post examples still work:
   - Create a new post example
   - Edit an existing post example
   - Delete a post example
   - View all post examples
3. Confirm that post generation still works with the examples functionality

### Why make this change?
The rename provides better clarity and specificity about the purpose of these components, making it clear they handle post examples specifically rather than generic examples. This improves code maintainability and reduces potential confusion for developers working with the codebase.